### PR TITLE
Add Slack bot package

### DIFF
--- a/packages/agent-slack-bot/package.json
+++ b/packages/agent-slack-bot/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@agentos/agent-slack-bot",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc -w",
+    "lint": "eslint src --ext .ts",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@agentos/core": "workspace:*",
+    "@agentos/llm-bridge-runner": "workspace:*",
+    "llm-bridge-spec": "^1.0.2",
+    "@slack/bolt": "^3.15.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.19",
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/agent-slack-bot/src/index.ts
+++ b/packages/agent-slack-bot/src/index.ts
@@ -1,0 +1,33 @@
+import { App } from '@slack/bolt';
+import { McpRegistry } from '@agentos/core';
+import { InMemoryLlmBridgeRegistry } from '@agentos/llm-bridge-runner';
+import { Message } from 'llm-bridge-spec';
+
+const app = new App({
+  token: process.env.SLACK_BOT_TOKEN || '',
+  signingSecret: process.env.SLACK_SIGNING_SECRET || '',
+});
+
+app.message(async ({ message, say }) => {
+  const text = (message as any).text ?? '';
+
+  // Placeholder: initialize AgentOS components
+  const mcpRegistry = new McpRegistry();
+  const llmBridgeRegistry = new InMemoryLlmBridgeRegistry();
+  const messages: Message[] = [{ role: 'user', content: [{ contentType: 'text', value: text }] }];
+  // TODO: Use agent from core with llmBridgeRegistry to process messages
+
+  await say(`Echo: ${text}`);
+});
+
+export async function start(port = 3000) {
+  await app.start(port);
+  console.log(`⚡️ Slack Bolt app is running on port ${port}!`);
+}
+
+if (require.main === module) {
+  start().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/agent-slack-bot/tsconfig.json
+++ b/packages/agent-slack-bot/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- scaffold `agent-slack-bot` package
- set up TypeScript config and dependencies
- add simple Slack Bolt app using AgentOS packages

## Testing
- `pnpm build` *(fails: Cannot find module 'llm-bridge-spec' etc)*