### PR TITLE
Fix pagination logic in file session

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "pnpm -r build",
     "dev": "pnpm -r dev",
     "lint": "pnpm -r lint",
+    "test": "pnpm -r test",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\""
   },
   "devDependencies": {
@@ -15,7 +16,10 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "prettier": "^3.2.5",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/packages/core/src/chat/file/__tests__/file-based-chat-session.test.ts
+++ b/packages/core/src/chat/file/__tests__/file-based-chat-session.test.ts
@@ -154,6 +154,48 @@ describe('FileBasedChatSession', () => {
       const result = await session.getHistories();
       expect(result.items).toContainEqual(mockHistory);
     });
+
+    it('cursor와 limit을 사용해 페이지네이션을 적용해야 한다', async () => {
+      const histories = [
+        {
+          messageId: '1',
+          createdAt: new Date(),
+          role: 'user',
+          content: { contentType: 'text', value: 'm1' },
+        },
+        {
+          messageId: '2',
+          createdAt: new Date(),
+          role: 'assistant',
+          content: { contentType: 'text', value: 'm2' },
+        },
+        {
+          messageId: '3',
+          createdAt: new Date(),
+          role: 'user',
+          content: { contentType: 'text', value: 'm3' },
+        },
+        {
+          messageId: '4',
+          createdAt: new Date(),
+          role: 'assistant',
+          content: { contentType: 'text', value: 'm4' },
+        },
+      ];
+
+      mockStorage.read.mockImplementation(async function* () {
+        for (const h of histories) {
+          yield h;
+        }
+      });
+
+      const result = await session.getHistories({ cursor: '1', limit: 2 });
+
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0]).toEqual(histories[1]);
+      expect(result.items[1]).toEqual(histories[2]);
+      expect(result.nextCursor).toBe('3');
+    });
   });
 
   describe('getCheckpoints', () => {

--- a/packages/core/src/chat/file/file-based-chat-session.ts
+++ b/packages/core/src/chat/file/file-based-chat-session.ts
@@ -108,13 +108,13 @@ export class FileBasedChatSession implements ChatSession {
     const buffer: MessageHistory[] = [];
 
     for await (const history of this.storage.read(this.sessionId)) {
+      if (cursor && Number(history.messageId) <= Number(cursor)) {
+        continue;
+      }
+
       buffer.push(history);
 
       if (buffer.length >= limit) {
-        break;
-      }
-
-      if (cursor && Number(history.messageId) < Number(cursor)) {
         break;
       }
     }


### PR DESCRIPTION
## Summary
- update iteration conditions in `file-based-chat-session`
- add pagination unit tests
- add Jest deps and root test script

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config and node_modules)*
- `pnpm test` *(fails: jest not found)*