### PR TITLE
Add chat list command

### DIFF
--- a/packages/cli/src/chat.ts
+++ b/packages/cli/src/chat.ts
@@ -1,0 +1,64 @@
+import readline from 'node:readline/promises';
+import path from 'node:path';
+import {
+  FileBasedChatManager,
+  FileBasedSessionStorage,
+  ChatSessionDescription,
+} from '@agentos/core';
+import { NoopCompressor } from './noop-compressor';
+import { Message } from 'llm-bridge-spec';
+
+function createManager(): FileBasedChatManager {
+  const baseDir = path.join(process.cwd(), '.agent', 'sessions');
+  const storage = new FileBasedSessionStorage(baseDir);
+  const compressor = new NoopCompressor();
+  return new FileBasedChatManager(storage, compressor, compressor);
+}
+
+export async function interactiveChat(): Promise<void> {
+  const manager = createManager();
+  const session = await manager.create();
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+  console.log('Type your message. Enter "exit" to quit.');
+
+  while (true) {
+    const input = await rl.question('You: ');
+    if (input.trim().toLowerCase() === 'exit') {
+      break;
+    }
+    const userMessage: Message = {
+      role: 'user',
+      content: { contentType: 'text', value: input },
+    };
+    await session.appendMessage(userMessage);
+
+    const response = `Echo: ${input}`;
+    const assistantMessage: Message = {
+      role: 'assistant',
+      content: { contentType: 'text', value: response },
+    };
+    await session.appendMessage(assistantMessage);
+    console.log('Assistant:', response);
+    await session.commit();
+  }
+
+  await session.commit();
+  rl.close();
+}
+
+export async function listSessions(): Promise<void> {
+  const manager = createManager();
+  const { items } = await manager.list();
+
+  if (items.length === 0) {
+    console.log('No chat sessions found.');
+    return;
+  }
+
+  items.forEach((item: ChatSessionDescription) => {
+    console.log(`${item.id}\t${item.title}\t${item.updatedAt.toISOString()}`);
+  });
+}
+

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { Agent } from '@agentos/core';
+import { interactiveChat, listSessions } from './chat';
 
 const program = new Command();
 
@@ -27,4 +28,31 @@ program
     }
   });
 
+const chat = program.command('chat').description('Chat commands');
+
+chat
+  .command('new')
+  .description('Start a new interactive chat session')
+  .action(async () => {
+    try {
+      await interactiveChat();
+    } catch (error) {
+      console.error(chalk.red('Error:'), error);
+      process.exit(1);
+    }
+  });
+
+chat
+  .command('list')
+  .description('List previous chat sessions')
+  .action(async () => {
+    try {
+      await listSessions();
+    } catch (error) {
+      console.error(chalk.red('Error:'), error);
+      process.exit(1);
+    }
+  });
+
 program.parse();
+

--- a/packages/cli/src/noop-compressor.ts
+++ b/packages/cli/src/noop-compressor.ts
@@ -1,0 +1,20 @@
+import { CompressStrategy, CompressionResult, MessageHistory } from '@agentos/core';
+import { ChatMessage } from 'llm-bridge-spec';
+
+/**
+ * A simple compressor that does nothing and returns a placeholder summary.
+ */
+export class NoopCompressor implements CompressStrategy {
+  async compress(messages: MessageHistory[]): Promise<CompressionResult> {
+    const summary: ChatMessage = {
+      role: 'system',
+      content: { contentType: 'text', value: 'summary not implemented' },
+    };
+
+    return {
+      summary,
+      compressedCount: messages.length,
+    };
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement `chat list` command for viewing sessions
- commit user inputs & responses in typed messages
- remove `any` from the no-op compressor

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config.js and dependencies)*
- `pnpm build` *(fails: missing TypeScript dependencies)*