### PR TITLE
Add chat UI for Electron renderer

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,9 @@ export * from './chat/chat-session-metata';
 export * from './chat/file/file-based-chat-session';
 export * from './chat/file/file-based-session-storage';
 
+export * from './agent/agent';
+export * from './agent/simple-agent';
+
 export * from './mcp/mcp';
 export * from './mcp/mcp-config';
 export * from './mcp/mcp-event';

--- a/packages/gui/src/renderer/ChatApp.tsx
+++ b/packages/gui/src/renderer/ChatApp.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { EchoAgent } from './EchoAgent';
+
+interface Message {
+  sender: 'user' | 'agent';
+  text: string;
+}
+
+const ChatApp: React.FC = () => {
+  const [messages, setMessages] = React.useState<Message[]>([]);
+  const [input, setInput] = React.useState('');
+  const [busy, setBusy] = React.useState(false);
+  const agentRef = React.useRef<EchoAgent>();
+  const endRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    agentRef.current = new EchoAgent();
+    agentRef.current.initialize().catch((err) => console.error(err));
+  }, []);
+
+  React.useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const handleSend = async () => {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+
+    setMessages((prev) => [...prev, { sender: 'user', text: trimmed }]);
+    setInput('');
+
+    try {
+      setBusy(true);
+      const response = await agentRef.current!.execute(trimmed);
+      setMessages((prev) => [...prev, { sender: 'agent', text: response }]);
+    } catch (error) {
+      console.error('Error:', error);
+      setMessages((prev) => [...prev, { sender: 'agent', text: 'Error executing task' }]);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div>
+      <div style={{ height: '400px', overflowY: 'auto', border: '1px solid #ccc', padding: '8px' }}>
+        {messages.map((m, idx) => (
+          <div key={idx} style={{ marginBottom: '8px' }}>
+            <strong>{m.sender === 'user' ? 'You' : 'Agent'}:</strong> {m.text}
+          </div>
+        ))}
+        <div ref={endRef} />
+      </div>
+      <div>
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              handleSend();
+            }
+          }}
+          placeholder="Type a message"
+          style={{ width: '80%' }}
+          disabled={busy}
+        />
+        <button onClick={handleSend} disabled={busy}>Send</button>
+      </div>
+    </div>
+  );
+};
+
+export default ChatApp;

--- a/packages/gui/src/renderer/EchoAgent.ts
+++ b/packages/gui/src/renderer/EchoAgent.ts
@@ -1,0 +1,9 @@
+export class EchoAgent {
+  async initialize(): Promise<void> {
+    // no-op for the simple echo agent
+  }
+
+  async execute(task: string): Promise<string> {
+    return `Echo: ${task}`;
+  }
+}

--- a/packages/gui/src/renderer/index.html
+++ b/packages/gui/src/renderer/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>AgentOS Chat</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="./index.js"></script>
+  </body>
+</html>

--- a/packages/gui/src/renderer/index.tsx
+++ b/packages/gui/src/renderer/index.tsx
@@ -1,50 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { Agent } from '@agentos/core';
-
-const App: React.FC = () => {
-  const [result, setResult] = React.useState<string>('');
-  const [task, setTask] = React.useState<string>('');
-
-  const handleExecute = async () => {
-    try {
-      const agent = new Agent({
-        name: 'default',
-        version: '1.0.0',
-      });
-      await agent.initialize();
-      const response = await agent.execute(task);
-      setResult(response);
-    } catch (error) {
-      console.error('Error:', error);
-      setResult('Error executing task');
-    }
-  };
-
-  return (
-    <div>
-      <h1>AgentOS GUI</h1>
-      <div>
-        <input
-          type="text"
-          value={task}
-          onChange={(e) => setTask(e.target.value)}
-          placeholder="Enter task"
-        />
-        <button onClick={handleExecute}>Execute</button>
-      </div>
-      {result && (
-        <div>
-          <h2>Result:</h2>
-          <pre>{result}</pre>
-        </div>
-      )}
-    </div>
-  );
-};
+import ChatApp from './ChatApp';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ChatApp />
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- create a simple chat component for the renderer
- wire the renderer entry to render the chat view
- add minimal HTML page for Electron to load
- export Agent interfaces from the core package
- implement a lightweight EchoAgent and improved ChatApp

## Testing
- `pnpm lint` *(fails: ESLint couldn't find configuration and node_modules missing)*
- `pnpm -r test` *(fails: jest not found and node_modules missing)*
