### PR TITLE
Improve type safety for LLM bridge demo

### DIFF
--- a/packages/agent-slack-bot/src/index.ts
+++ b/packages/agent-slack-bot/src/index.ts
@@ -1,4 +1,4 @@
-import { App } from '@slack/bolt';
+import { App, GenericMessageEvent } from '@slack/bolt';
 import { McpRegistry } from '@agentos/core';
 import { InMemoryLlmBridgeRegistry } from '@agentos/llm-bridge-runner';
 import { Message } from 'llm-bridge-spec';
@@ -8,8 +8,12 @@ const app = new App({
   signingSecret: process.env.SLACK_SIGNING_SECRET || '',
 });
 
+function isGenericMessageEvent(msg: unknown): msg is GenericMessageEvent {
+  return !!msg && typeof (msg as GenericMessageEvent).text === 'string';
+}
+
 app.message(async ({ message, say }) => {
-  const text = (message as any).text ?? '';
+  const text = isGenericMessageEvent(message) ? message.text : '';
 
   // Placeholder: initialize AgentOS components
   const mcpRegistry = new McpRegistry();

--- a/packages/cli/src/chat.ts
+++ b/packages/cli/src/chat.ts
@@ -28,8 +28,9 @@ export async function interactiveChat() {
       content: { contentType: 'text', value: `Echo: ${input}` },
     };
     await session.appendMessage(assistantMessage);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    console.log('Assistant:', (assistantMessage.content as any).value);
+    if (assistantMessage.content.contentType === 'text') {
+      console.log('Assistant:', assistantMessage.content.value);
+    }
   }
 
   await session.commit();

--- a/packages/gui/jest.config.js
+++ b/packages/gui/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+};

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -7,7 +7,8 @@
     "build": "tsc && electron-builder",
     "dev": "concurrently \"tsc -w\" \"electron .\"",
     "lint": "eslint src --ext .ts,.tsx",
-    "start": "electron ."
+    "start": "electron .",
+    "test": "jest"
   },
   "dependencies": {
     "@agentos/core": "workspace:*",

--- a/packages/gui/src/renderer/BridgeManager.ts
+++ b/packages/gui/src/renderer/BridgeManager.ts
@@ -1,0 +1,35 @@
+import { LlmBridge } from 'llm-bridge-spec';
+
+export class BridgeManager {
+  private bridges = new Map<string, LlmBridge>();
+  private currentId?: string;
+
+  register(id: string, bridge: LlmBridge): void {
+    this.bridges.set(id, bridge);
+    if (!this.currentId) {
+      this.currentId = id;
+    }
+  }
+
+  async switchBridge(id: string): Promise<void> {
+    if (!this.bridges.has(id)) {
+      throw new Error(`Bridge ${id} not registered`);
+    }
+    this.currentId = id;
+  }
+
+  getCurrentBridge(): LlmBridge {
+    if (!this.currentId) {
+      throw new Error('No bridge selected');
+    }
+    return this.bridges.get(this.currentId)!;
+  }
+
+  getCurrentId(): string | undefined {
+    return this.currentId;
+  }
+
+  getBridgeIds(): string[] {
+    return Array.from(this.bridges.keys());
+  }
+}

--- a/packages/gui/src/renderer/EchoAgent.ts
+++ b/packages/gui/src/renderer/EchoAgent.ts
@@ -1,9 +1,0 @@
-export class EchoAgent {
-  async initialize(): Promise<void> {
-    // no-op for the simple echo agent
-  }
-
-  async execute(task: string): Promise<string> {
-    return `Echo: ${task}`;
-  }
-}

--- a/packages/gui/src/renderer/__tests__/bridge-manager.test.ts
+++ b/packages/gui/src/renderer/__tests__/bridge-manager.test.ts
@@ -1,0 +1,37 @@
+import { BridgeManager } from '../BridgeManager';
+import { LlmBridge, LlmBridgePrompt, LlmBridgeResponse, LlmMetadata } from 'llm-bridge-spec';
+
+class DummyBridge implements LlmBridge {
+  constructor(private readonly id: string) {}
+  async invoke(_prompt: LlmBridgePrompt): Promise<LlmBridgeResponse> {
+    return { content: { contentType: 'text', value: this.id } };
+  }
+  async getMetadata(): Promise<LlmMetadata> {
+    return {
+      name: this.id,
+      version: '1.0',
+      description: '',
+      model: '',
+      contextWindow: 0,
+      maxTokens: 0,
+    };
+  }
+}
+
+test('switchBridge changes active bridge', async () => {
+  const manager = new BridgeManager();
+  manager.register('a', new DummyBridge('a'));
+  manager.register('b', new DummyBridge('b'));
+  await manager.switchBridge('b');
+  const result = await manager.getCurrentBridge().invoke({ messages: [] });
+  if (result.content.contentType !== 'text') {
+    throw new Error('Unexpected content type');
+  }
+  expect(result.content.value).toBe('b');
+});
+
+test('switching to unknown bridge throws', async () => {
+  const manager = new BridgeManager();
+  manager.register('a', new DummyBridge('a'));
+  await expect(manager.switchBridge('x')).rejects.toThrow();
+});

--- a/packages/gui/src/renderer/bridges/EchoBridge.ts
+++ b/packages/gui/src/renderer/bridges/EchoBridge.ts
@@ -1,0 +1,22 @@
+import { LlmBridge, LlmBridgePrompt, LlmBridgeResponse, LlmMetadata } from 'llm-bridge-spec';
+
+export default class EchoBridge implements LlmBridge {
+  async invoke(prompt: LlmBridgePrompt): Promise<LlmBridgeResponse> {
+    const last = prompt.messages[prompt.messages.length - 1];
+    const text = last && last.content.contentType === 'text' ? last.content.value : '';
+    return {
+      content: { contentType: 'text', value: `Echo: ${text}` },
+    };
+  }
+
+  async getMetadata(): Promise<LlmMetadata> {
+    return {
+      name: 'Echo Bridge',
+      version: '1.0.0',
+      description: 'Simple echo bridge',
+      model: 'echo',
+      contextWindow: 0,
+      maxTokens: 0,
+    };
+  }
+}

--- a/packages/gui/src/renderer/bridges/ReverseBridge.ts
+++ b/packages/gui/src/renderer/bridges/ReverseBridge.ts
@@ -1,0 +1,23 @@
+import { LlmBridge, LlmBridgePrompt, LlmBridgeResponse, LlmMetadata } from 'llm-bridge-spec';
+
+export default class ReverseBridge implements LlmBridge {
+  async invoke(prompt: LlmBridgePrompt): Promise<LlmBridgeResponse> {
+    const last = prompt.messages[prompt.messages.length - 1];
+    const text = last && last.content.contentType === 'text' ? last.content.value : '';
+    const reversed = [...String(text)].reverse().join('');
+    return {
+      content: { contentType: 'text', value: reversed },
+    };
+  }
+
+  async getMetadata(): Promise<LlmMetadata> {
+    return {
+      name: 'Reverse Bridge',
+      version: '1.0.0',
+      description: 'Reverse text bridge',
+      model: 'reverse',
+      contextWindow: 0,
+      maxTokens: 0,
+    };
+  }
+}

--- a/packages/llm-bridge-runner/src/index.ts
+++ b/packages/llm-bridge-runner/src/index.ts
@@ -3,3 +3,4 @@ export * from './registry/in-memory/in-memory-llm-bridge.registry';
 export * from './loader/types';
 export * from './loader/dependecy/dependency-llm-bridge.loader';
 export * from './loader/dependecy/dependency-llm-bridge.bootstrap';
+export * from './loader/file/file-llm-bridge.loader';

--- a/packages/llm-bridge-runner/src/loader/file/file-llm-bridge.loader.ts
+++ b/packages/llm-bridge-runner/src/loader/file/file-llm-bridge.loader.ts
@@ -1,0 +1,37 @@
+import { pathToFileURL } from 'url';
+import { LlmManifest } from 'llm-bridge-spec';
+
+import { FileLlmBridgeLoader, LlmBridgeBootstrap } from '../types';
+import { parseLlmBridgeConfig } from '../dependecy/parseLlmBridgeConfig';
+import { DependencyLlmBridgeBootstrap } from '../dependecy/dependency-llm-bridge.bootstrap';
+import { LlmBridgeConstructor } from '../dependecy/llm-bridge-constructor';
+
+export class LocalFileLlmBridgeLoader implements FileLlmBridgeLoader {
+  async load(moduleName: string): Promise<LlmBridgeBootstrap> {
+    return this.loadFromPath(moduleName);
+  }
+
+  async loadFromPath(filePath: string): Promise<LlmBridgeBootstrap> {
+    const loaded = await this.loadLlmBridgeFromPath(filePath);
+    return new DependencyLlmBridgeBootstrap(loaded);
+  }
+
+  private async loadLlmBridgeFromPath(filePath: string): Promise<LoadedLlmBridge> {
+    const mod = (await import(pathToFileURL(filePath).href)) as {
+      manifest: () => LlmManifest;
+      default: LlmBridgeConstructor<any[]>;
+    };
+
+    return {
+      manifest: mod.manifest(),
+      configSchema: parseLlmBridgeConfig(mod.manifest()),
+      ctor: mod.default,
+    };
+  }
+}
+
+export type LoadedLlmBridge = {
+  manifest: LlmManifest;
+  configSchema: ReturnType<typeof parseLlmBridgeConfig>;
+  ctor: LlmBridgeConstructor<any[]>;
+};

--- a/packages/llm-bridge-runner/src/loader/types.ts
+++ b/packages/llm-bridge-runner/src/loader/types.ts
@@ -11,3 +11,7 @@ export interface LlmBridgeBootstrap {
 
   create<T extends Record<string, any>>(config: T): Promise<LlmBridge>;
 }
+
+export interface FileLlmBridgeLoader extends LlmBridgeLoader {
+  loadFromPath(filePath: string): Promise<LlmBridgeBootstrap>;
+}


### PR DESCRIPTION
## Summary
- remove `any` casts in Slack bot example
- make CLI and GUI bridges check content type before using values
- update GUI bridge manager test for stronger typing

## Testing
- `pnpm lint`
- `pnpm test` *(fails: network issues during tests)*
- `pnpm build` *(fails: type errors in packages/core)*

------
https://chatgpt.com/codex/tasks/task_e_6840efc38a88832e9a068f50c77bf38a