### PR TITLE
Fix GUI Type Errors

### DIFF
--- a/packages/gui/src/renderer/bridges/EchoBridge.ts
+++ b/packages/gui/src/renderer/bridges/EchoBridge.ts
@@ -3,7 +3,12 @@ import { LlmBridge, LlmBridgePrompt, LlmBridgeResponse, LlmMetadata } from 'llm-
 export default class EchoBridge implements LlmBridge {
   async invoke(prompt: LlmBridgePrompt): Promise<LlmBridgeResponse> {
     const last = prompt.messages[prompt.messages.length - 1];
-    const text = last && last.content.contentType === 'text' ? last.content.value : '';
+    const content = last
+      ? Array.isArray(last.content)
+        ? last.content[0]
+        : last.content
+      : undefined;
+    const text = content && content.contentType === 'text' ? String(content.value) : '';
     return {
       content: { contentType: 'text', value: `Echo: ${text}` },
     };

--- a/packages/gui/src/renderer/bridges/ReverseBridge.ts
+++ b/packages/gui/src/renderer/bridges/ReverseBridge.ts
@@ -3,7 +3,12 @@ import { LlmBridge, LlmBridgePrompt, LlmBridgeResponse, LlmMetadata } from 'llm-
 export default class ReverseBridge implements LlmBridge {
   async invoke(prompt: LlmBridgePrompt): Promise<LlmBridgeResponse> {
     const last = prompt.messages[prompt.messages.length - 1];
-    const text = last && last.content.contentType === 'text' ? last.content.value : '';
+    const content = last
+      ? Array.isArray(last.content)
+        ? last.content[0]
+        : last.content
+      : undefined;
+    const text = content && content.contentType === 'text' ? String(content.value) : '';
     const reversed = [...String(text)].reverse().join('');
     return {
       content: { contentType: 'text', value: reversed },

--- a/packages/gui/tsconfig.json
+++ b/packages/gui/tsconfig.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "lib": ["ES2020", "DOM"],
+    "paths": {
+      "llm-bridge-spec": ["../core/node_modules/llm-bridge-spec"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
### 계획서

**요구사항**
- GUI 패키지 빌드 시 발생하는 타입 오류를 해결한다.
- `llm-bridge-spec` 모듈의 타입을 인식하고 DOM API 사용 시 오류가 없도록 한다.
- 브리지 구현이 `MultiModalContent[]` 형태의 메시지도 안전하게 처리한다.

**인터페이스 초안**
- `tsconfig.json`에 `lib: ["ES2020", "DOM"]` 추가
- `tsconfig.json`에 `paths` 설정으로 `llm-bridge-spec` 위치 지정
- `EchoBridge.invoke(prompt)` 및 `ReverseBridge.invoke(prompt)`에서 메시지의 `content`가 배열인 경우 첫 요소 사용

**Todo 리스트**
1. `packages/gui/tsconfig.json` 수정
2. `EchoBridge.ts` 업데이트
3. `ReverseBridge.ts` 업데이트
4. `pnpm format`, `pnpm lint`, `pnpm test` 실행

**작업 순서**
1. 설정 파일 수정 후 브리지 코드 수정
2. 포맷 및 린트 실행
3. 테스트 실행 후 커밋

### 변경 내용
- GUI tsconfig에 DOM 라이브러리와 `llm-bridge-spec` 경로 매핑을 추가했습니다.
- EchoBridge와 ReverseBridge가 배열 형태의 `content`도 처리하도록 수정했습니다.
- `pnpm format`, `pnpm lint`, `pnpm test`를 실행했습니다 (테스트는 네트워크 오류로 실패).


------
https://chatgpt.com/codex/tasks/task_e_6845818b574c832eb245d5d74378a064