### PR TITLE
Fix CLI build issues

### DIFF
--- a/CLI_COMPILE_FIX_PLAN.md
+++ b/CLI_COMPILE_FIX_PLAN.md
@@ -1,0 +1,33 @@
+# CLI Compile Fix Plan
+
+## Requirements
+- Resolve TypeScript build errors in `packages/cli`.
+- Remove dependency on `CursorPaginationResult` from `@agentos/core`.
+- Introduce CLI specific pagination result type.
+
+## Interface Sketch
+```ts
+// packages/cli/src/pagination.ts
+export interface PaginationResult<T> {
+  items: T[];
+  nextCursor?: string;
+}
+
+export async function* paginate<T>(
+  fetch: (cursor?: string) => Promise<PaginationResult<T>>
+): AsyncGenerator<T[]>;
+```
+
+## Todo
+- [ ] Define `PaginationResult` interface.
+- [ ] Update `paginate` helpers to return/use this type.
+- [ ] Refactor `browse.ts` and `history.ts` to use new type and fix generics.
+- [ ] Add guards for multi-modal content to satisfy type checks.
+- [ ] Ensure optional cursor handling compiles.
+- [ ] Run `pnpm lint`, `pnpm build`, and `pnpm test`.
+
+## Steps
+1. Add `PaginationResult` definition in `packages/cli/src/pagination.ts` and adjust code.
+2. Update `packages/cli/src/utils/paginate.ts` accordingly.
+3. Fix `browse.ts` and `history.ts` type issues (generics, cursor optional, message content guard).
+4. Run lint, build and tests from repo root.

--- a/packages/cli/src/browse.ts
+++ b/packages/cli/src/browse.ts
@@ -15,7 +15,11 @@ export async function browseSessions(): Promise<void> {
   // eslint-disable-next-line no-constant-condition
   while (true) {
     if (!pages[pageIndex]) {
-      const { items, nextCursor } = await manager.list({ cursor, limit: 5 });
+      const { items, nextCursor } = await manager.list({
+        cursor: cursor ?? '',
+        limit: 5,
+        direction: 'forward',
+      });
       pages[pageIndex] = items;
       cursors[pageIndex + 1] = nextCursor || undefined;
     }
@@ -66,14 +70,18 @@ export async function browseHistory(
   const rl = rlParam ?? readline.createInterface({ input: process.stdin, output: process.stdout });
 
   let cursor: string | undefined;
-  const pages: MessageHistory[][] = [];
+  const pages: Readonly<MessageHistory>[][] = [];
   const cursors: (string | undefined)[] = [];
   let pageIndex = 0;
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
     if (!pages[pageIndex]) {
-      const { items, nextCursor } = await session.getHistories({ cursor, limit: 5 });
+      const { items, nextCursor } = await session.getHistories({
+        cursor: cursor ?? '',
+        limit: 5,
+        direction: 'forward',
+      });
       pages[pageIndex] = items;
       cursors[pageIndex + 1] = nextCursor || undefined;
     }
@@ -81,7 +89,10 @@ export async function browseHistory(
 
     console.log(chalk.yellow(`\nHistory (page ${pageIndex + 1})`));
     for (const message of page) {
-      const content = message.content.contentType === 'text' ? message.content.value : '[non-text]';
+      const content =
+        !Array.isArray(message.content) && message.content.contentType === 'text'
+          ? message.content.value
+          : '[non-text]';
       const time = message.createdAt.toISOString();
       console.log(`${chalk.gray('[' + time + ']')} ${chalk.cyan(message.role)}: ${content}`);
     }

--- a/packages/cli/src/chat.ts
+++ b/packages/cli/src/chat.ts
@@ -13,8 +13,10 @@ export async function interactiveChat() {
     .on(/^history$/i, async () => {
       const { items } = await session.getHistories();
       for (const msg of items) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const text = (msg.content as any).value;
+        const text =
+          !Array.isArray(msg.content) && msg.content.contentType === 'text'
+            ? msg.content.value
+            : '[non-text]';
         console.log(`${msg.role}: ${text}`);
       }
     })
@@ -31,8 +33,11 @@ export async function interactiveChat() {
         content: { contentType: 'text', value: `Echo: ${input}` },
       };
       await session.appendMessage(assistantMessage);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      console.log('Assistant:', (assistantMessage.content as any).value);
+      const text =
+        !Array.isArray(assistantMessage.content) && assistantMessage.content.contentType === 'text'
+          ? assistantMessage.content.value
+          : '[non-text]';
+      console.log('Assistant:', text);
     });
 
   const stream = builder.build();

--- a/packages/cli/src/history.ts
+++ b/packages/cli/src/history.ts
@@ -13,9 +13,15 @@ export async function browseHistory(sessionId: string): Promise<void> {
     output: process.stdout,
   });
 
-  const iterator = paginate((cursor?: string) => session.getHistories({ cursor, limit: 20 }));
+  const iterator = paginate<Readonly<MessageHistory>>(async (cursor?: string) =>
+    session.getHistories({
+      cursor: cursor ?? '',
+      limit: 20,
+      direction: 'forward',
+    })
+  );
 
-  const pages: MessageHistory[][] = [];
+  const pages: Readonly<MessageHistory>[][] = [];
   let pageIndex = 0;
 
   const loadNext = async () => {
@@ -38,7 +44,10 @@ export async function browseHistory(sessionId: string): Promise<void> {
     console.log(chalk.yellow(`\n-- Messages Page ${pageIndex + 1} --`));
     const page = pages[pageIndex];
     for (const message of page) {
-      const content = message.content.contentType === 'text' ? message.content.value : '[non-text]';
+      const content =
+        !Array.isArray(message.content) && message.content.contentType === 'text'
+          ? message.content.value
+          : '[non-text]';
       const time = message.createdAt.toISOString();
       console.log(`${chalk.gray('[' + time + ']')} ${chalk.cyan(message.role)}: ${content}`);
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,6 @@
 
 import { Command } from 'commander';
 import chalk from 'chalk';
-import { SimpleAgent } from '@agentos/core';
 import { interactiveChat } from './chat';
 import { browseHistory } from './history';
 import { browseSessions } from './sessions';

--- a/packages/cli/src/pagination.ts
+++ b/packages/cli/src/pagination.ts
@@ -1,7 +1,10 @@
-import { CursorPaginationResult } from '@agentos/core';
+export interface PaginationResult<T> {
+  items: T[];
+  nextCursor?: string;
+}
 
 export async function* paginate<T>(
-  fetch: (cursor?: string) => Promise<CursorPaginationResult<T>>
+  fetch: (cursor?: string) => Promise<PaginationResult<T>>
 ): AsyncGenerator<T[]> {
   let cursor: string | undefined;
   // eslint-disable-next-line no-constant-condition

--- a/packages/cli/src/sessions.ts
+++ b/packages/cli/src/sessions.ts
@@ -19,7 +19,7 @@ export async function browseSessions(): Promise<void> {
     const end = start + pageSize;
     const page = items.slice(start, end);
     console.log(chalk.yellow(`\n-- Sessions Page ${pageIndex + 1}/${pages} --`));
-    page.forEach((s, idx) => {
+    page.forEach((s: (typeof items)[number], idx: number) => {
       const title = s.title || '(no title)';
       const time = s.updatedAt.toISOString();
       console.log(`${idx + 1}. [${time}] ${s.id} - ${title}`);

--- a/packages/cli/src/utils/paginate.ts
+++ b/packages/cli/src/utils/paginate.ts
@@ -1,13 +1,13 @@
-import { CursorPaginationResult } from '@agentos/core';
+import { PaginationResult } from '../pagination';
 
 /**
  * Generic async generator for cursor pagination.
  * `fetch` should accept an optional cursor and return a page of items.
  */
 export async function* paginate<T>(
-  fetch: (cursor?: string) => Promise<CursorPaginationResult<T>>,
+  fetch: (cursor?: string) => Promise<PaginationResult<T>>,
   startCursor?: string
-): AsyncGenerator<CursorPaginationResult<T>> {
+): AsyncGenerator<PaginationResult<T>> {
   let cursor = startCursor;
   while (true) {
     const page = await fetch(cursor);


### PR DESCRIPTION
## Summary
- refine CLI pagination to avoid `any`
- clean up chat and history browsing logic
- fix type warnings in session listing
- remove unused import in CLI entry

## Testing
- `pnpm lint`
- `pnpm --filter @agentos/core build`
- `pnpm --filter @agentos/cli build`
- `pnpm test` *(fails: npm registry unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684581374d1c832e80c98b17b8a66f0d