### PR TITLE
Implement CLI bootstrap DI

### DIFF
--- a/CLI_BOOTSTRAP_PLAN.md
+++ b/CLI_BOOTSTRAP_PLAN.md
@@ -1,0 +1,34 @@
+# CLI Bootstrap Plan
+
+## Requirements
+- Avoid recreating `ChatManager` and related components each time a CLI command runs.
+- Provide a bootstrap function assembling singletons on startup.
+- Use dependency injection by passing the `ChatManager` instance to command handlers.
+- Update existing CLI command modules to accept the injected manager.
+
+## Interface Sketch
+```ts
+// packages/cli/src/bootstrap.ts
+export interface AppContext {
+  chatManager: ChatManager;
+}
+export function bootstrap(): AppContext;
+
+// packages/cli/src/chat.ts
+export async function interactiveChat(manager: ChatManager): Promise<void>;
+```
+Other command modules (`history.ts`, `sessions.ts`, `browse.ts`) will have similar signatures that receive `ChatManager`.
+
+## Todo
+- [ ] Implement `bootstrap` that creates a singleton `ChatManager`.
+- [ ] Refactor `interactiveChat`, `browseHistory`, and `browseSessions` to accept `ChatManager`.
+- [ ] Update callers in `index.ts` and between modules.
+- [ ] Ensure existing exports remain (e.g. `showHistory`).
+- [ ] Run `pnpm lint`, `pnpm build`, and `pnpm test`.
+
+## Steps
+1. Create `packages/cli/src/bootstrap.ts` returning an `AppContext` with a singleton `ChatManager` using existing factory logic.
+2. Modify command modules (`chat.ts`, `history.ts`, `sessions.ts`, `browse.ts`) to accept a `ChatManager` parameter instead of creating one internally.
+3. Update internal calls and CLI entry (`index.ts`) to initialize context via `bootstrap()` once and pass the manager to command functions.
+4. Export alias `showHistory` from `history.ts` unchanged for compatibility.
+5. Run lint, build, and tests from repository root.

--- a/packages/cli/src/bootstrap.ts
+++ b/packages/cli/src/bootstrap.ts
@@ -1,0 +1,16 @@
+import { ChatManager } from '@agentos/core';
+import { createManager } from './chat-manager';
+
+export interface AppContext {
+  chatManager: ChatManager;
+}
+
+let context: AppContext | null = null;
+
+export function bootstrap(): AppContext {
+  if (!context) {
+    const chatManager = createManager();
+    context = { chatManager };
+  }
+  return context;
+}

--- a/packages/cli/src/browse.ts
+++ b/packages/cli/src/browse.ts
@@ -1,10 +1,8 @@
 import readline from 'node:readline/promises';
 import chalk from 'chalk';
 import { ChatManager, ChatSessionDescription, MessageHistory } from '@agentos/core';
-import { createManager } from './chat-manager';
 
-export async function browseSessions(): Promise<void> {
-  const manager: ChatManager = createManager();
+export async function browseSessions(manager: ChatManager): Promise<void> {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
   let cursor: string | undefined;
@@ -51,7 +49,7 @@ export async function browseSessions(): Promise<void> {
     } else {
       const num = Number(input);
       if (!Number.isNaN(num) && num > 0 && num <= page.length) {
-        await browseHistory(page[num - 1].id, rl);
+        await browseHistory(manager, page[num - 1].id, rl);
       } else {
         console.log('Invalid input');
       }
@@ -62,10 +60,10 @@ export async function browseSessions(): Promise<void> {
 }
 
 export async function browseHistory(
+  manager: ChatManager,
   sessionId: string,
   rlParam?: readline.Interface
 ): Promise<void> {
-  const manager: ChatManager = createManager();
   const session = await manager.load({ sessionId });
   const rl = rlParam ?? readline.createInterface({ input: process.stdin, output: process.stdout });
 

--- a/packages/cli/src/chat.ts
+++ b/packages/cli/src/chat.ts
@@ -1,10 +1,8 @@
 import { Message } from 'llm-bridge-spec';
 import { ChatManager } from '@agentos/core';
-import { createManager } from './chat-manager';
 import { createUserInputStream } from './utils/user-input-stream';
 
-export async function interactiveChat() {
-  const manager: ChatManager = createManager();
+export async function interactiveChat(manager: ChatManager) {
   const session = await manager.create();
 
   console.log('Type your message. Enter "quit" to exit. Use "history" to view messages.');

--- a/packages/cli/src/history.ts
+++ b/packages/cli/src/history.ts
@@ -1,11 +1,9 @@
 import chalk from 'chalk';
 import readline from 'node:readline/promises';
 import { ChatManager, MessageHistory } from '@agentos/core';
-import { createManager } from './chat-manager';
 import { paginate } from './pagination';
 
-export async function browseHistory(sessionId: string): Promise<void> {
-  const manager: ChatManager = createManager();
+export async function browseHistory(manager: ChatManager, sessionId: string): Promise<void> {
   const session = await manager.load({ sessionId });
 
   const rl = readline.createInterface({

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,8 +5,10 @@ import chalk from 'chalk';
 import { interactiveChat } from './chat';
 import { browseHistory } from './history';
 import { browseSessions } from './sessions';
+import { bootstrap } from './bootstrap';
 
 const program = new Command();
+const { chatManager } = bootstrap();
 
 program.name('agentos').description('CLI for AgentOS').version('1.0.0');
 
@@ -23,7 +25,7 @@ program
   .description('Start an interactive chat session')
   .action(async () => {
     try {
-      await interactiveChat();
+      await interactiveChat(chatManager);
     } catch (error) {
       console.error(chalk.red('Error:'), error);
       process.exit(1);
@@ -36,7 +38,7 @@ program
   .argument('<sessionId>', 'Session ID to load')
   .action(async (sessionId: string) => {
     try {
-      await browseHistory(sessionId);
+      await browseHistory(chatManager, sessionId);
     } catch (error) {
       console.error(chalk.red('Error:'), error);
       process.exit(1);
@@ -48,7 +50,7 @@ program
   .description('Browse previous chat sessions')
   .action(async () => {
     try {
-      await browseSessions();
+      await browseSessions(chatManager);
     } catch (error) {
       console.error(chalk.red('Error:'), error);
       process.exit(1);

--- a/packages/cli/src/sessions.ts
+++ b/packages/cli/src/sessions.ts
@@ -1,11 +1,9 @@
 import readline from 'node:readline/promises';
 import chalk from 'chalk';
 import { ChatManager } from '@agentos/core';
-import { createManager } from './chat-manager';
 import { browseHistory } from './history';
 
-export async function browseSessions(): Promise<void> {
-  const manager: ChatManager = createManager();
+export async function browseSessions(manager: ChatManager): Promise<void> {
   const { items } = await manager.list();
   const pageSize = 10;
   const pages = Math.ceil(items.length / pageSize);
@@ -42,7 +40,7 @@ export async function browseSessions(): Promise<void> {
       const num = parseInt(input, 10);
       if (!Number.isNaN(num) && num >= 1 && num <= page.length) {
         const session = page[num - 1];
-        await browseHistory(session.id);
+        await browseHistory(manager, session.id);
       }
     }
   }


### PR DESCRIPTION
## Summary
- add plan for bootstrapping CLI components
- introduce `bootstrap()` to create a singleton `ChatManager`
- inject `ChatManager` into CLI command functions
- refactor chat, history, session browsing functions to use DI

## Testing
- `pnpm lint`
- `pnpm -F cli build`
- `pnpm test` *(fails: ENETUNREACH when running core tests)*

------
https://chatgpt.com/codex/tasks/task_e_68477fc6dc64832eac808e1cca8b806e