### PR TITLE
Implement quit command for paging

### DIFF
--- a/CLI_USER_INPUT_PLAN.md
+++ b/CLI_USER_INPUT_PLAN.md
@@ -1,0 +1,26 @@
+# CLI User Input Plan
+
+## 요구사항
+- `browseSessions`와 `browseHistory`에서 페이징 탐색을 위한 입력 처리에 `UserInputStreamBuilder`를 사용한다.
+- `(n)ext`, `(p)rev`, `(q)uit` 및 번호 선택 명령을 정규식으로 처리한다.
+- 함수 시그니처는 유지하되 내부 구현을 단순화한다.
+
+## 인터페이스 초안
+```ts
+// packages/cli/src/sessions.ts
+export async function browseSessions(manager: ChatManager): Promise<void>;
+
+// packages/cli/src/history.ts
+export async function browseHistory(manager: ChatManager, sessionId: string): Promise<void>;
+```
+
+## Todo 리스트
+- [ ] `browseSessions`에서 `UserInputStreamBuilder`를 이용해 입력 루프를 재작성
+- [ ] `browseHistory`에서 동일하게 적용
+- [ ] `pnpm lint`와 `pnpm test` 실행
+
+## 작업 순서
+1. `packages/cli/src/utils/user-input-stream.ts` 사용 예시를 참고하여 두 함수에서 입력 스트림을 생성한다.
+2. 각 명령에 대한 콜백에서 페이지 이동 및 출력 로직을 수행한다.
+3. 기존 `readline` 구현을 제거한다.
+4. 프로젝트 루트에서 `pnpm lint`와 `pnpm test`를 실행한다.

--- a/packages/cli/src/sessions.ts
+++ b/packages/cli/src/sessions.ts
@@ -1,18 +1,16 @@
-import readline from 'node:readline/promises';
 import chalk from 'chalk';
 import { ChatManager } from '@agentos/core';
 import { browseHistory } from './history';
+import { createUserInputStream } from './utils/user-input-stream';
 
 export async function browseSessions(manager: ChatManager): Promise<void> {
   const { items } = await manager.list();
   const pageSize = 10;
   const pages = Math.ceil(items.length / pageSize);
 
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-
   let pageIndex = 0;
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
+
+  const showPage = () => {
     const start = pageIndex * pageSize;
     const end = start + pageSize;
     const page = items.slice(start, end);
@@ -22,28 +20,40 @@ export async function browseSessions(manager: ChatManager): Promise<void> {
       const time = s.updatedAt.toISOString();
       console.log(`${idx + 1}. [${time}] ${s.id} - ${title}`);
     });
+  };
 
-    const input = await rl.question('(number) open, (n)ext, (p)rev, (q)uit: ');
-    if (input === 'n') {
+  const stream = createUserInputStream({
+    prompt: '(number) open, (n)ext, (p)rev, (q)uit: ',
+  })
+    .quit('q')
+    .on(/^n$/i, async () => {
       if (pageIndex + 1 < pages) {
         pageIndex++;
+        showPage();
       } else {
         console.log('No next page.');
       }
-    } else if (input === 'p') {
+    })
+    .on(/^p$/i, async () => {
       if (pageIndex > 0) {
         pageIndex--;
+        showPage();
       }
-    } else if (input === 'q') {
-      break;
-    } else {
-      const num = parseInt(input, 10);
+    })
+    .on(/^(\d+)$/i, async (m) => {
+      const num = parseInt(m[1], 10);
+      const start = pageIndex * pageSize;
+      const end = start + pageSize;
+      const page = items.slice(start, end);
       if (!Number.isNaN(num) && num >= 1 && num <= page.length) {
         const session = page[num - 1];
         await browseHistory(manager, session.id);
+        showPage();
       }
-    }
-  }
+    })
+    .build();
 
-  rl.close();
+  showPage();
+
+  await stream.run();
 }

--- a/packages/cli/src/utils/__tests__/user-input-stream.test.ts
+++ b/packages/cli/src/utils/__tests__/user-input-stream.test.ts
@@ -15,6 +15,19 @@ describe('UserInputStream', () => {
     await expect(runPromise).resolves.toBeUndefined();
   });
 
+  it('resolves with custom quit command', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+
+    const builder = createUserInputStream({ input, output, prompt: '' }).quit('q');
+    const stream = builder.on(/.*/, async () => {}).build();
+
+    const runPromise = stream.run();
+    input.write('q\n');
+
+    await expect(runPromise).resolves.toBeUndefined();
+  });
+
   it('invokes matching handler', async () => {
     const input = new PassThrough();
     const output = new PassThrough();


### PR DESCRIPTION
## Summary
- extend `UserInputStreamBuilder` with a `quit()` command registration
- simplify browsing logic in `browseHistory` and `browseSessions`
- update tests for custom quit commands

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68478677ddf0832e874b1012586f7a00