### PR TITLE
Implement sidebar history in GUI

### DIFF
--- a/GUI_HISTORY_SIDEBAR_PLAN.md
+++ b/GUI_HISTORY_SIDEBAR_PLAN.md
@@ -1,0 +1,39 @@
+# GUI History Sidebar Plan
+
+## Requirements
+
+- Save chat messages using `@agentos/core` so conversations persist.
+- Provide a sidebar menu in the React GUI listing previous sessions (id, title, updated date).
+- Selecting a session loads its messages into the main chat view.
+- Allow starting a new session from the sidebar.
+- Keep ChatApp slim by extracting the sidebar into a separate `ChatSidebar` component.
+
+## Interface Sketch
+
+```ts
+// packages/gui/src/renderer/chat-manager.ts
+export function createChatManager(): ChatManager;
+
+// packages/gui/src/renderer/ChatApp.tsx
+// uses createChatManager() and maintains session state
+// packages/gui/src/renderer/ChatSidebar.tsx
+// displays previous sessions and controls switching
+```
+
+## Todo
+
+- [ ] Add `NoopCompressor` and `createChatManager` in renderer code.
+- [ ] Update `ChatApp` to persist messages via a `ChatSession`.
+- [ ] Fetch session list and display in a sidebar with open/new actions.
+- [ ] Load selected session history using `ChatSession.getHistories`.
+- [ ] Run `pnpm lint` and `pnpm test`.
+- [ ] Extract sidebar rendering into a new `ChatSidebar` component.
+
+## Steps
+
+1. Implement `NoopCompressor` and `createChatManager` similar to CLI's factory.
+2. Refactor `ChatApp` to create a manager and a session on mount.
+3. Add sidebar UI to list sessions and switch between them; load history when switching.
+4. Append and commit messages to the active session when chatting.
+5. Split out `ChatSidebar` component to keep `ChatApp` manageable.
+6. Update tests if needed and run lint/tests.

--- a/packages/gui/src/renderer/ChatApp.tsx
+++ b/packages/gui/src/renderer/ChatApp.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { BridgeManager } from './BridgeManager';
 import EchoBridge from './bridges/EchoBridge';
 import ReverseBridge from './bridges/ReverseBridge';
+import { ChatManager, ChatSession, ChatSessionDescription, MessageHistory } from '@agentos/core';
+import { createChatManager } from './chat-manager';
+import ChatSidebar from './ChatSidebar';
 
 interface Message {
   sender: 'user' | 'agent';
@@ -12,16 +15,75 @@ const manager = new BridgeManager();
 manager.register('echo', new EchoBridge());
 manager.register('reverse', new ReverseBridge());
 
+const chatManager: ChatManager = createChatManager();
+
 const ChatApp: React.FC = () => {
   const [messages, setMessages] = React.useState<Message[]>([]);
   const [input, setInput] = React.useState('');
   const [busy, setBusy] = React.useState(false);
   const [bridgeId, setBridgeId] = React.useState(manager.getCurrentId()!);
+  const [sessions, setSessions] = React.useState<ChatSessionDescription[]>([]);
+  const [session, setSession] = React.useState<ChatSession | null>(null);
   const endRef = React.useRef<HTMLDivElement>(null);
+
+  const refreshSessions = React.useCallback(async () => {
+    const { items } = await chatManager.list();
+    setSessions(items);
+  }, []);
+
+  const loadHistories = React.useCallback(async (s: ChatSession) => {
+    const all: MessageHistory[] = [];
+    let cursor = '';
+    for (;;) {
+      const { items, nextCursor } = await s.getHistories({
+        cursor,
+        limit: 20,
+        direction: 'forward',
+      });
+      all.push(...items);
+      if (!nextCursor || items.length === 0) break;
+      cursor = nextCursor;
+    }
+    return all;
+  }, []);
+
+  const openSession = React.useCallback(
+    async (id: string) => {
+      const loaded = await chatManager.load({ sessionId: id });
+      const histories = await loadHistories(loaded);
+      setSession(loaded);
+      setMessages(
+        histories.map((h) => ({
+          sender: h.role === 'user' ? 'user' : 'agent',
+          text:
+            !Array.isArray(h.content) && h.content.contentType === 'text'
+              ? String(h.content.value)
+              : '',
+        }))
+      );
+    },
+    [loadHistories]
+  );
+
+  const startNewSession = React.useCallback(async () => {
+    const newS = await chatManager.create();
+    setSession(newS);
+    setMessages([]);
+    await refreshSessions();
+  }, [refreshSessions]);
 
   React.useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
+
+  React.useEffect(() => {
+    const init = async () => {
+      const newSession = await chatManager.create();
+      setSession(newSession);
+      await refreshSessions();
+    };
+    void init();
+  }, []);
 
   const handleSend = async () => {
     const trimmed = input.trim();
@@ -29,6 +91,13 @@ const ChatApp: React.FC = () => {
 
     setMessages((prev) => [...prev, { sender: 'user', text: trimmed }]);
     setInput('');
+
+    if (session) {
+      await session.appendMessage({
+        role: 'user',
+        content: { contentType: 'text', value: trimmed },
+      });
+    }
 
     try {
       setBusy(true);
@@ -38,6 +107,15 @@ const ChatApp: React.FC = () => {
       const content = llmResponse.content;
       const text = content.contentType === 'text' ? String(content.value) : '';
       setMessages((prev) => [...prev, { sender: 'agent', text }]);
+
+      if (session) {
+        await session.appendMessage({
+          role: 'assistant',
+          content: { contentType: 'text', value: text },
+        });
+        await session.commit();
+        await refreshSessions();
+      }
     } catch (error) {
       console.error('Error:', error);
       setMessages((prev) => [...prev, { sender: 'agent', text: 'Error executing task' }]);
@@ -47,51 +125,66 @@ const ChatApp: React.FC = () => {
   };
 
   return (
-    <div>
-      <div style={{ marginBottom: '8px' }}>
-        <label htmlFor="bridge">LLM Bridge: </label>
-        <select
-          id="bridge"
-          value={bridgeId}
-          onChange={async (e) => {
-            const id = e.target.value;
-            await manager.switchBridge(id);
-            setBridgeId(id);
+    <div style={{ display: 'flex', height: '100%' }}>
+      <ChatSidebar
+        sessions={sessions}
+        currentSessionId={session?.sessionId}
+        onNew={startNewSession}
+        onOpen={openSession}
+      />
+      <div style={{ flex: 1, padding: '8px' }}>
+        <div style={{ marginBottom: '8px' }}>
+          <label htmlFor="bridge">LLM Bridge: </label>
+          <select
+            id="bridge"
+            value={bridgeId}
+            onChange={async (e) => {
+              const id = e.target.value;
+              await manager.switchBridge(id);
+              setBridgeId(id);
+            }}
+          >
+            {manager.getBridgeIds().map((id) => (
+              <option key={id} value={id}>
+                {id}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div
+          style={{
+            height: '400px',
+            overflowY: 'auto',
+            border: '1px solid #ccc',
+            padding: '8px',
           }}
         >
-          {manager.getBridgeIds().map((id) => (
-            <option key={id} value={id}>
-              {id}
-            </option>
+          {messages.map((m, idx) => (
+            <div key={idx} style={{ marginBottom: '8px' }}>
+              <strong>{m.sender === 'user' ? 'You' : 'Agent'}:</strong> {m.text}
+            </div>
           ))}
-        </select>
-      </div>
-      <div style={{ height: '400px', overflowY: 'auto', border: '1px solid #ccc', padding: '8px' }}>
-        {messages.map((m, idx) => (
-          <div key={idx} style={{ marginBottom: '8px' }}>
-            <strong>{m.sender === 'user' ? 'You' : 'Agent'}:</strong> {m.text}
-          </div>
-        ))}
-        <div ref={endRef} />
-      </div>
-      <div>
-        <input
-          type="text"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault();
-              handleSend();
-            }
-          }}
-          placeholder="Type a message"
-          style={{ width: '80%' }}
-          disabled={busy}
-        />
-        <button onClick={handleSend} disabled={busy}>
-          Send
-        </button>
+          <div ref={endRef} />
+        </div>
+        <div>
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleSend();
+              }
+            }}
+            placeholder="Type a message"
+            style={{ width: '80%' }}
+            disabled={busy}
+          />
+          <button onClick={handleSend} disabled={busy}>
+            Send
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/packages/gui/src/renderer/ChatSidebar.tsx
+++ b/packages/gui/src/renderer/ChatSidebar.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { ChatSessionDescription } from '@agentos/core';
+
+interface ChatSidebarProps {
+  sessions: ChatSessionDescription[];
+  currentSessionId?: string;
+  onNew: () => void;
+  onOpen: (id: string) => void;
+}
+
+const ChatSidebar: React.FC<ChatSidebarProps> = ({ sessions, currentSessionId, onNew, onOpen }) => {
+  return (
+    <div style={{ width: '250px', borderRight: '1px solid #ccc', padding: '8px' }}>
+      <button onClick={onNew}>New Chat</button>
+      <div style={{ marginTop: '8px' }}>
+        {sessions.map((s) => (
+          <div
+            key={s.id}
+            onClick={() => onOpen(s.id)}
+            style={{
+              cursor: 'pointer',
+              fontWeight: currentSessionId === s.id ? 'bold' : 'normal',
+              marginBottom: '4px',
+            }}
+          >
+            {s.title || '(no title)'}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ChatSidebar;

--- a/packages/gui/src/renderer/NoopCompressor.ts
+++ b/packages/gui/src/renderer/NoopCompressor.ts
@@ -1,0 +1,13 @@
+import { CompressStrategy, CompressionResult, MessageHistory } from '@agentos/core';
+
+export class NoopCompressor implements CompressStrategy {
+  async compress(messages: MessageHistory[]): Promise<CompressionResult> {
+    return {
+      summary: {
+        role: 'system',
+        content: { contentType: 'text', value: 'summary not implemented' },
+      },
+      compressedCount: messages.length,
+    };
+  }
+}

--- a/packages/gui/src/renderer/__tests__/chat-manager.test.ts
+++ b/packages/gui/src/renderer/__tests__/chat-manager.test.ts
@@ -1,0 +1,13 @@
+import { createChatManager } from '../chat-manager';
+
+test('createChatManager returns working manager', async () => {
+  const manager = createChatManager();
+  const session = await manager.create();
+  await session.appendMessage({
+    role: 'user',
+    content: { contentType: 'text', value: 'hi' },
+  });
+  await session.commit();
+  const { items } = await manager.list();
+  expect(items.length).toBeGreaterThan(0);
+});

--- a/packages/gui/src/renderer/chat-manager.ts
+++ b/packages/gui/src/renderer/chat-manager.ts
@@ -1,0 +1,10 @@
+import path from 'node:path';
+import { ChatManager, FileBasedChatManager, FileBasedSessionStorage } from '@agentos/core';
+import { NoopCompressor } from './NoopCompressor';
+
+export function createChatManager(): ChatManager {
+  const baseDir = path.join(process.cwd(), '.agent', 'sessions');
+  const storage = new FileBasedSessionStorage(baseDir);
+  const compressor = new NoopCompressor();
+  return new FileBasedChatManager(storage, compressor, compressor);
+}


### PR DESCRIPTION
## Summary
- plan GUI history sidebar
- add NoopCompressor and chat manager for the GUI
- persist chat messages using core ChatManager
- show previous sessions in a new sidebar
- basic test for the GUI chat manager
- refactor sidebar rendering to dedicated component

## Testing
- `pnpm lint`
- `pnpm test` *(fails: npm registry unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6848237b311c832ea61bae65a55d0828