### PR TITLE
Add GUI session selection

### DIFF
--- a/GUI_HISTORY_SIDEBAR_PLAN.md
+++ b/GUI_HISTORY_SIDEBAR_PLAN.md
@@ -22,18 +22,18 @@ export function createChatManager(): ChatManager;
 
 ## Todo
 
-- [ ] Add `NoopCompressor` and `createChatManager` in renderer code.
-- [ ] Update `ChatApp` to persist messages via a `ChatSession`.
-- [ ] Fetch session list and display in a sidebar with open/new actions.
-- [ ] Load selected session history using `ChatSession.getHistories`.
-- [ ] Run `pnpm lint` and `pnpm test`.
-- [ ] Extract sidebar rendering into a new `ChatSidebar` component.
+- [x] Add `NoopCompressor` and `createChatManager` in renderer code.
+- [x] Update `ChatApp` to persist messages via a `ChatSession`.
+- [x] Fetch session list and display in a sidebar with open/new actions.
+- [x] Load selected session history using `ChatSession.getHistories`.
+- [x] Run `pnpm lint` and `pnpm test`.
+- [x] Extract sidebar rendering into a new `ChatSidebar` component.
 
 ## Steps
 
-1. Implement `NoopCompressor` and `createChatManager` similar to CLI's factory.
-2. Refactor `ChatApp` to create a manager and a session on mount.
-3. Add sidebar UI to list sessions and switch between them; load history when switching.
-4. Append and commit messages to the active session when chatting.
-5. Split out `ChatSidebar` component to keep `ChatApp` manageable.
-6. Update tests if needed and run lint/tests.
+1. Implement `NoopCompressor` and `createChatManager` similar to CLI's factory. ✅
+2. Refactor `ChatApp` to create a manager and a session on mount. ✅
+3. Add sidebar UI to list sessions and switch between them; load history when switching. ✅
+4. Append and commit messages to the active session when chatting. ✅
+5. Split out `ChatSidebar` component to keep `ChatApp` manageable. ✅
+6. Update tests if needed and run lint/tests. ✅

--- a/GUI_PREVIOUS_SESSION_PLAN.md
+++ b/GUI_PREVIOUS_SESSION_PLAN.md
@@ -1,0 +1,29 @@
+# GUI Previous Session Selection Plan
+
+## 요구사항
+- 사용자는 사이드바에서 이전 대화 세션 목록을 확인할 수 있다.
+- 세션을 선택하면 해당 대화 기록이 메인 채팅창에 로드되고, 이후 대화를 이어 나갈 수 있다.
+
+## 인터페이스 초안
+```ts
+// packages/gui/src/renderer/ChatSidebar.tsx
+interface ChatSidebarProps {
+  sessions: ChatSessionDescription[];
+  currentSessionId?: string;
+  onNew: () => void;
+  onOpen: (id: string) => void;
+}
+```
+
+## Todo
+- [x] `ChatApp` 에 세션을 로드하고 상태를 관리하는 로직 구현
+- [x] `ChatSidebar` 컴포넌트에서 세션 리스트 표시 및 선택 기능 제공
+- [x] 세션 선택 시 `ChatSession.getHistories` 로 메시지를 불러오기
+- [x] 새 세션 생성 기능 추가
+- [x] `pnpm lint` 와 `pnpm test` 실행
+
+## 작업 순서
+1. `ChatSidebar` UI 작성 및 props 정의 ✅
+2. `ChatApp` 에서 `ChatManager` 로 세션 목록을 불러오고 상태 관리 ✅
+3. 세션 로드 함수 구현 후 메시지 히스토리를 메인 뷰에 출력 ✅
+4. 테스트 및 린트 실행 후 커밋 ✅

--- a/packages/gui/src/renderer/ChatSidebar.tsx
+++ b/packages/gui/src/renderer/ChatSidebar.tsx
@@ -23,7 +23,9 @@ const ChatSidebar: React.FC<ChatSidebarProps> = ({ sessions, currentSessionId, o
               marginBottom: '4px',
             }}
           >
-            {s.title || '(no title)'}
+            <div>{s.title || '(no title)'}</div>
+            <div style={{ fontSize: '0.8em', color: '#666' }}>{s.id}</div>
+            <div style={{ fontSize: '0.8em', color: '#666' }}>{s.updatedAt.toLocaleString()}</div>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- show session metadata in GUI sidebar so users can reopen old chats

## Testing
- `pnpm lint`
- `pnpm test` *(fails: npm registry unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6848d5135ae8832e889f16868cf76905