### PR TITLE
Add MCP list screen to GUI

### DIFF
--- a/packages/gui/docs/GUI_MCP_LIST_PLAN.md
+++ b/packages/gui/docs/GUI_MCP_LIST_PLAN.md
@@ -1,0 +1,28 @@
+# GUI MCP List Plan
+
+## 요구사항
+- GUI에서 사용자가 저장한 MCP 목록을 보여 주는 화면을 제공한다.
+- 왼쪽 사이드바 메뉴에서 해당 화면을 열 수 있어야 한다.
+- 각 항목은 MCP 이름과 타입을 기본 정보로 표시한다.
+- 향후 편집 기능 확장을 고려해 단순한 구조로 구현한다.
+
+## 인터페이스 초안
+```ts
+// packages/gui/src/renderer/McpList.tsx
+interface McpListProps {
+  mcps: McpConfig[];
+  onClose(): void;
+}
+```
+사이드바에 "MCPs" 메뉴를 추가하여 목록 화면을 열도록 변경할 예정이다.
+
+## Todo
+- [ ] `McpList` 컴포넌트 작성
+- [ ] `ChatSidebar`에 "MCPs" 메뉴 항목 추가
+- [ ] `ChatApp`에 `showMcpList` 상태를 도입해 화면 전환
+- [ ] 기본 렌더 테스트 포함 후 `pnpm lint`와 `pnpm test` 실행
+
+## 작업 순서
+1. `McpList` 작성 후 단위 테스트 추가
+2. `ChatSidebar`와 `ChatApp`을 수정하여 목록 화면을 열고 닫는 기능 구현
+3. 린트와 테스트 실행 후 커밋

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -19,9 +19,11 @@
   "devDependencies": {
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
+    "@types/react-test-renderer": "^18.0.0",
     "concurrently": "^8.2.2",
     "electron": "^28.2.0",
     "electron-builder": "^24.9.1",
+    "react-test-renderer": "^18.2.0",
     "typescript": "^5.3.3"
   }
 }

--- a/packages/gui/src/renderer/ChatApp.tsx
+++ b/packages/gui/src/renderer/ChatApp.tsx
@@ -14,6 +14,7 @@ import { createChatManager } from './chat-manager';
 import ChatSidebar from './ChatSidebar';
 import ChatTabs from './ChatTabs';
 import McpSettings from './McpSettings';
+import McpList from './McpList';
 import { McpConfigStore } from './mcp-config-store';
 import { loadMcpFromStore } from './mcp-loader';
 
@@ -39,6 +40,7 @@ const ChatApp: React.FC = () => {
   const [openTabIds, setOpenTabIds] = React.useState<string[]>([]);
   const [activeTabId, setActiveTabId] = React.useState<string>('');
   const [showSettings, setShowSettings] = React.useState(false);
+  const [showMcpList, setShowMcpList] = React.useState(false);
   const [mcp, setMcp] = React.useState<Mcp | undefined>(undefined);
   const endRef = React.useRef<HTMLDivElement>(null);
 
@@ -166,8 +168,15 @@ const ChatApp: React.FC = () => {
         currentSessionId={activeTabId || session?.sessionId}
         onNew={startNewSession}
         onOpen={openSession}
+        onShowMcps={() => setShowMcpList(true)}
       />
       <div style={{ flex: 1, padding: '8px' }}>
+        {showMcpList && (
+          <McpList
+            mcps={mcpConfigStore.get() ? [mcpConfigStore.get() as McpConfig] : []}
+            onClose={() => setShowMcpList(false)}
+          />
+        )}
         <button onClick={() => setShowSettings(true)} style={{ marginBottom: '8px' }}>
           MCP Settings
         </button>

--- a/packages/gui/src/renderer/ChatSidebar.tsx
+++ b/packages/gui/src/renderer/ChatSidebar.tsx
@@ -6,12 +6,22 @@ interface ChatSidebarProps {
   currentSessionId?: string;
   onNew: () => void;
   onOpen: (id: string) => void;
+  onShowMcps: () => void;
 }
 
-const ChatSidebar: React.FC<ChatSidebarProps> = ({ sessions, currentSessionId, onNew, onOpen }) => {
+const ChatSidebar: React.FC<ChatSidebarProps> = ({
+  sessions,
+  currentSessionId,
+  onNew,
+  onOpen,
+  onShowMcps,
+}) => {
   return (
     <div style={{ width: '250px', borderRight: '1px solid #ccc', padding: '8px' }}>
       <button onClick={onNew}>New Chat</button>
+      <button onClick={onShowMcps} style={{ marginTop: '8px' }}>
+        MCPs
+      </button>
       <div style={{ marginTop: '8px' }}>
         {sessions.map((s) => (
           <div

--- a/packages/gui/src/renderer/McpList.tsx
+++ b/packages/gui/src/renderer/McpList.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { McpConfig } from '@agentos/core';
+
+export interface McpListProps {
+  mcps: McpConfig[];
+  onClose(): void;
+}
+
+const McpList: React.FC<McpListProps> = ({ mcps, onClose }) => {
+  return (
+    <div style={{ padding: '8px' }}>
+      <button onClick={onClose} style={{ marginBottom: '8px' }}>
+        Close
+      </button>
+      {mcps.length === 0 ? (
+        <div>No MCPs configured.</div>
+      ) : (
+        <ul>
+          {mcps.map((mcp, idx) => (
+            <li key={idx}>
+              <strong>{mcp.name}</strong> ({mcp.type})
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default McpList;

--- a/packages/gui/src/renderer/__tests__/mcp-list.test.ts
+++ b/packages/gui/src/renderer/__tests__/mcp-list.test.ts
@@ -1,0 +1,22 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import McpList from '../McpList';
+import { McpConfig } from '@agentos/core';
+
+const sample: McpConfig = {
+  type: 'stdio',
+  name: 'test',
+  version: '1',
+  command: 'echo',
+};
+
+test('renders empty message', () => {
+  const tree = renderer.create(<McpList mcps={[]} onClose={() => {}} />).toJSON();
+  expect(tree).toBeTruthy();
+});
+
+test('renders provided MCPs', () => {
+  const component = renderer.create(<McpList mcps={[sample]} onClose={() => {}} />);
+  const li = component.root.findByType('li');
+  expect(li.children.join('')).toContain('test');
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.19
         version: 18.3.6(@types/react@18.3.20)
+      '@types/react-test-renderer':
+        specifier: ^18.0.0
+        version: 18.3.1
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
@@ -157,6 +160,9 @@ importers:
       electron-builder:
         specifier: ^24.9.1
         version: 24.13.3(electron-builder-squirrel-windows@24.13.3)
+      react-test-renderer:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -693,6 +699,9 @@ packages:
     resolution: {integrity: sha512-nf22//wEbKXusP6E9pfOCDwFdHAX4u172eaJI4YkDRQEZiorm6KfYnSC2SWLDMVWUOWPERmJnN0ujeAfTBLvrw==}
     peerDependencies:
       '@types/react': ^18.0.0
+
+  '@types/react-test-renderer@18.3.1':
+    resolution: {integrity: sha512-vAhnk0tG2eGa37lkU9+s5SoroCsRI08xnsWFiAXOuPH2jqzMbcXvKExXViPi1P5fIklDeCvXqyrdmipFaSkZrA==}
 
   '@types/react@18.3.20':
     resolution: {integrity: sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==}
@@ -2834,6 +2843,16 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-shallow-renderer@16.15.0:
+    resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0
+
+  react-test-renderer@18.3.1:
+    resolution: {integrity: sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==}
+    peerDependencies:
+      react: ^18.3.1
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -4211,6 +4230,10 @@ snapshots:
   '@types/range-parser@1.2.7': {}
 
   '@types/react-dom@18.3.6(@types/react@18.3.20)':
+    dependencies:
+      '@types/react': 18.3.20
+
+  '@types/react-test-renderer@18.3.1':
     dependencies:
       '@types/react': 18.3.20
 
@@ -6840,6 +6863,19 @@ snapshots:
       scheduler: 0.23.2
 
   react-is@18.3.1: {}
+
+  react-shallow-renderer@16.15.0(react@18.3.1):
+    dependencies:
+      object-assign: 4.1.1
+      react: 18.3.1
+      react-is: 18.3.1
+
+  react-test-renderer@18.3.1(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-is: 18.3.1
+      react-shallow-renderer: 16.15.0(react@18.3.1)
+      scheduler: 0.23.2
 
   react@18.3.1:
     dependencies:


### PR DESCRIPTION
## Summary
- plan MCP list view
- implement `McpList` component
- show MCP list from sidebar
- basic component test

## Testing
- `pnpm lint`
- `pnpm test` *(fails: npm registry unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684fc952e240832eb45d783709f5fd4c