### PR TITLE
Add preset manager with file storage

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,3 +15,4 @@ export * from './mcp/mcp.registery';
 
 export * from './preset/preset';
 export * from './preset/preset.repository';
+export * from './preset/file-based-preset.repository';

--- a/packages/core/src/preset/__tests__/file-based-preset.repository.test.ts
+++ b/packages/core/src/preset/__tests__/file-based-preset.repository.test.ts
@@ -1,0 +1,46 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { tmpdir } from 'os';
+import { FileBasedPresetRepository } from '../file-based-preset.repository';
+import { Preset } from '../preset';
+
+describe('FileBasedPresetRepository', () => {
+  const base = path.join(tmpdir(), 'preset-repo-test');
+  const repo = new FileBasedPresetRepository(base);
+  const preset: Preset = {
+    id: 'p1',
+    name: 'test',
+    description: '',
+    author: '',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    version: '1.0.0',
+    systemPrompt: '',
+    enabledMcps: [],
+    llmBridgeName: '',
+    llmBridgeConfig: {},
+  };
+
+  afterEach(async () => {
+    await fs.rm(base, { recursive: true, force: true });
+  });
+
+  test('create and get', async () => {
+    await repo.create(preset);
+    const loaded = await repo.get(preset.id);
+    expect(loaded?.name).toBe('test');
+  });
+
+  test('list', async () => {
+    await repo.create(preset);
+    const { items } = await repo.list();
+    expect(items.length).toBe(1);
+  });
+
+  test('delete', async () => {
+    await repo.create(preset);
+    await repo.delete(preset.id);
+    const { items } = await repo.list();
+    expect(items.length).toBe(0);
+  });
+});

--- a/packages/core/src/preset/file-based-preset.repository.ts
+++ b/packages/core/src/preset/file-based-preset.repository.ts
@@ -1,0 +1,67 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { CursorPaginationResult } from '../common/pagination/cursor-pagination';
+import { Preset } from './preset';
+import { PresetRepository, PresetSummary } from './preset.repository';
+
+export class FileBasedPresetRepository implements PresetRepository {
+  constructor(private readonly baseDir: string) {}
+
+  async list(): Promise<CursorPaginationResult<PresetSummary>> {
+    await fs.mkdir(this.baseDir, { recursive: true });
+    const entries = await fs.readdir(this.baseDir);
+    const items: PresetSummary[] = [];
+    for (const entry of entries) {
+      if (!entry.endsWith('.json')) continue;
+      const preset = await this.get(entry.replace(/\.json$/, ''));
+      if (preset) {
+        items.push({
+          id: preset.id,
+          name: preset.name,
+          description: preset.description,
+          updatedAt: preset.updatedAt,
+        });
+      }
+    }
+    items.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+    return { items, nextCursor: '' };
+  }
+
+  async get(id: string): Promise<Preset | null> {
+    try {
+      const filePath = this.resolvePath(id);
+      const raw = await fs.readFile(filePath, 'utf-8');
+      const data = JSON.parse(raw);
+      return {
+        ...data,
+        createdAt: new Date(data.createdAt),
+        updatedAt: new Date(data.updatedAt),
+      } as Preset;
+    } catch {
+      return null;
+    }
+  }
+
+  async create(preset: Preset): Promise<void> {
+    await this.saveFile(preset.id, preset);
+  }
+
+  async update(id: string, preset: Preset): Promise<void> {
+    await this.saveFile(id, preset);
+  }
+
+  async delete(id: string): Promise<void> {
+    const filePath = this.resolvePath(id);
+    await fs.rm(filePath, { force: true });
+  }
+
+  private async saveFile(id: string, preset: Preset): Promise<void> {
+    await fs.mkdir(this.baseDir, { recursive: true });
+    const filePath = this.resolvePath(id);
+    await fs.writeFile(filePath, JSON.stringify(preset, null, 2), 'utf-8');
+  }
+
+  private resolvePath(id: string): string {
+    return path.join(this.baseDir, `${id}.json`);
+  }
+}

--- a/packages/gui/src/renderer/ChatApp.tsx
+++ b/packages/gui/src/renderer/ChatApp.tsx
@@ -15,6 +15,7 @@ import ChatSidebar from './ChatSidebar';
 import ChatTabs from './ChatTabs';
 import McpSettings from './McpSettings';
 import McpList from './McpList';
+import SettingsMenu from './SettingsMenu';
 import { McpConfigStore } from './mcp-config-store';
 import { loadMcpFromStore } from './mcp-loader';
 
@@ -181,6 +182,7 @@ const ChatApp: React.FC = () => {
           MCP Settings
         </button>
         {showSettings && <McpSettings initial={mcpConfigStore.get()} onSave={handleSaveMcp} />}
+        <SettingsMenu />
         <ChatTabs
           tabs={openTabIds.map((id) => ({
             id,

--- a/packages/gui/src/renderer/PresetManager.tsx
+++ b/packages/gui/src/renderer/PresetManager.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import { Preset } from '@agentos/core';
+import { PresetStore, loadPresets, savePreset, deletePreset } from './preset-store';
+
+const store = new PresetStore();
+
+const emptyPreset = (): Preset => ({
+  id: Date.now().toString(),
+  name: '',
+  description: '',
+  author: '',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  version: '1.0.0',
+  systemPrompt: '',
+  enabledMcps: [],
+  llmBridgeName: '',
+  llmBridgeConfig: {},
+});
+
+const PresetManager: React.FC = () => {
+  const [presets, setPresets] = useState<Preset[]>([]);
+  const [current, setCurrent] = useState<Preset>(emptyPreset());
+
+  useEffect(() => {
+    loadPresets(store).then(setPresets);
+  }, []);
+
+  const handleSave = async () => {
+    await savePreset(store, { ...current, updatedAt: new Date() });
+    setCurrent(emptyPreset());
+    setPresets(await loadPresets(store));
+  };
+
+  const handleDelete = async (id: string) => {
+    await deletePreset(store, id);
+    setPresets(await loadPresets(store));
+  };
+
+  return (
+    <div style={{ padding: '8px' }}>
+      <h3>Presets</h3>
+      <ul>
+        {presets.map((p) => (
+          <li key={p.id}>
+            {p.name}{' '}
+            <button onClick={() => handleDelete(p.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+      <div style={{ marginTop: '8px' }}>
+        <input
+          value={current.name}
+          onChange={(e) => setCurrent({ ...current, name: e.target.value })}
+          placeholder="Preset name"
+        />
+        <button onClick={handleSave}>Add</button>
+      </div>
+    </div>
+  );
+};
+
+export default PresetManager;

--- a/packages/gui/src/renderer/SettingsMenu.tsx
+++ b/packages/gui/src/renderer/SettingsMenu.tsx
@@ -1,0 +1,14 @@
+import React, { useState } from 'react';
+import PresetManager from './PresetManager';
+
+const SettingsMenu: React.FC = () => {
+  const [showPresets, setShowPresets] = useState(false);
+  return (
+    <div style={{ marginBottom: '8px' }}>
+      <button onClick={() => setShowPresets((p) => !p)}>Preset Manager</button>
+      {showPresets && <PresetManager />}
+    </div>
+  );
+};
+
+export default SettingsMenu;

--- a/packages/gui/src/renderer/__tests__/preset-store.test.ts
+++ b/packages/gui/src/renderer/__tests__/preset-store.test.ts
@@ -1,0 +1,36 @@
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { Preset } from '@agentos/core';
+import { PresetStore, loadPresets, savePreset, deletePreset } from '../preset-store';
+
+const tempDir = path.join(tmpdir(), 'preset-store-test');
+
+const sample: Preset = {
+  id: '1',
+  name: 'sample',
+  description: '',
+  author: '',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  version: '1.0.0',
+  systemPrompt: '',
+  enabledMcps: [],
+  llmBridgeName: '',
+  llmBridgeConfig: {},
+};
+
+test('save and load presets', async () => {
+  const store = new PresetStore({ cwd: tempDir });
+  await savePreset(store, sample);
+  const presets = await loadPresets(store);
+  expect(presets).toHaveLength(1);
+  expect(presets[0].name).toBe('sample');
+});
+
+test('delete preset', async () => {
+  const store = new PresetStore({ cwd: tempDir + '2' });
+  await savePreset(store, sample);
+  await deletePreset(store, sample.id);
+  const presets = await loadPresets(store);
+  expect(presets).toHaveLength(0);
+});

--- a/packages/gui/src/renderer/preset-store.ts
+++ b/packages/gui/src/renderer/preset-store.ts
@@ -1,0 +1,41 @@
+import Store from 'electron-store';
+import { Preset } from '@agentos/core';
+
+export class PresetStore {
+  private store: Store<{ presets: Preset[] }>;
+
+  constructor(options?: Store.Options<{ presets: Preset[] }>) {
+    this.store = new Store<{ presets: Preset[] }>({
+      name: 'presets',
+      defaults: { presets: [] },
+      ...options,
+    });
+  }
+
+  list(): Preset[] {
+    return this.store.get('presets');
+  }
+
+  save(preset: Preset): void {
+    const presets = this.list().filter((p) => p.id !== preset.id);
+    presets.push(preset);
+    this.store.set('presets', presets);
+  }
+
+  delete(id: string): void {
+    const presets = this.list().filter((p) => p.id !== id);
+    this.store.set('presets', presets);
+  }
+}
+
+export async function loadPresets(store: PresetStore): Promise<Preset[]> {
+  return store.list();
+}
+
+export async function savePreset(store: PresetStore, preset: Preset): Promise<void> {
+  store.save(preset);
+}
+
+export async function deletePreset(store: PresetStore, id: string): Promise<void> {
+  store.delete(id);
+}


### PR DESCRIPTION
## Summary
- create `FileBasedPresetRepository` in core for storing presets on disk
- expose new repository from core index
- add electron-store based `PresetStore` and UI components `PresetManager` and `SettingsMenu`
- show settings menu from ChatApp
- basic unit tests for preset store and file-based repository

## Testing
- `pnpm test` *(fails: npm registry network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851875bd808832ebe7e8a5cac4ff1db