### PR TITLE
Add refactor plan for growing GUI ChatApp

### DIFF
--- a/packages/gui/docs/GUI_CHATAPP_REFACTOR_PLAN.md
+++ b/packages/gui/docs/GUI_CHATAPP_REFACTOR_PLAN.md
@@ -1,0 +1,42 @@
+# GUI ChatApp Refactor Plan
+
+## Requirements
+- The `ChatApp` component is growing and becoming hard to maintain.
+- Separate responsibilities so each piece has a clear focus.
+
+## Interface Sketch
+```ts
+// packages/gui/src/renderer/ChatMessageList.tsx
+interface ChatMessageListProps {
+  messages: Message[];
+}
+
+// packages/gui/src/renderer/ChatInput.tsx
+interface ChatInputProps {
+  onSend(text: string): void;
+  disabled?: boolean;
+}
+
+// packages/gui/src/renderer/useChatSession.ts
+function useChatSession(chatManager: ChatManager): {
+  session: ChatSession | null;
+  openSession(id: string): Promise<void>;
+  startNewSession(preset?: Preset): Promise<void>;
+  messages: Message[];
+  send(text: string): Promise<void>;
+};
+```
+
+## Todo
+- [ ] Create `ChatMessageList` and `ChatInput` components.
+- [ ] Extract session handling logic into `useChatSession` hook.
+- [ ] Replace direct state management in `ChatApp` with the new hook and components.
+- [ ] Ensure existing features (tabs, sidebar, preset selector) continue to work.
+- [ ] Run `pnpm lint` and `pnpm test`.
+
+## Steps
+1. Implement `useChatSession` to encapsulate session lifecycle and message flow.
+2. Build `ChatMessageList` and `ChatInput` for the chat area UI.
+3. Refactor `ChatApp` to use these pieces and remove redundant state.
+4. Update or add tests for the new components and hook.
+5. Run lint and tests before committing.


### PR DESCRIPTION
## Summary
- document a plan for refactoring `ChatApp` into smaller pieces

## Testing
- `pnpm lint` *(fails: prettier error in PresetManager.tsx)*
- `pnpm test` *(fails: network unreachable during core tests)*

------
https://chatgpt.com/codex/tasks/task_e_68535ef448e8832e803d3adeea642b75