### PR TITLE
Add slack-block-builder

### DIFF
--- a/docs/settings-block-plan.md
+++ b/docs/settings-block-plan.md
@@ -1,0 +1,23 @@
+# Settings Block Plan
+
+## 요구사항
+- 슬랙 봇의 설정 화면을 렌더링하기 위한 Block 구성 함수를 작성한다.
+- block 구성은 `slack-block-builder` 패키지를 이용하여 간결하게 표현한다.
+
+## 인터페이스 초안
+```ts
+// packages/agent-slack-bot/src/settings-block.ts
+export function getSettingsBlocks(): KnownBlock[];
+```
+
+## Todo
+- [ ] `slack-block-builder` 의존성 추가
+- [ ] `getSettingsBlocks` 구현: 섹션 헤더와 닫기 버튼을 포함한 blocks 반환
+- [ ] 단위 테스트 작성
+- [ ] `pnpm lint` 와 `pnpm test` 실행 후 커밋
+
+## 작업 순서
+1. 패키지 의존성 업데이트 후 설치
+2. `settings-block.ts` 파일에 함수 구현
+3. Jest 테스트 작성하여 결과 검증
+4. 문서에 사용법과 의존성 추가 사실 기록

--- a/packages/agent-slack-bot/jest.config.js
+++ b/packages/agent-slack-bot/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+};

--- a/packages/agent-slack-bot/package.json
+++ b/packages/agent-slack-bot/package.json
@@ -8,13 +8,16 @@
     "build": "tsc",
     "dev": "tsc -w",
     "lint": "eslint src --ext .ts",
+    "test": "jest",
     "start": "node dist/index.js"
   },
   "dependencies": {
     "@agentos/core": "workspace:*",
     "@agentos/llm-bridge-runner": "workspace:*",
     "llm-bridge-spec": "^1.0.2",
-    "@slack/bolt": "^3.15.0"
+    "@slack/bolt": "^3.15.0",
+    "slack-block-builder": "^2.8.0",
+    "@slack/types": "^2.14.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.19",

--- a/packages/agent-slack-bot/src/__tests__/settings-block.test.ts
+++ b/packages/agent-slack-bot/src/__tests__/settings-block.test.ts
@@ -1,0 +1,13 @@
+import { Message, Blocks, Elements } from 'slack-block-builder';
+import { getSettingsBlocks } from '../settings-block';
+import { KnownBlock } from '@slack/types';
+
+test('getSettingsBlocks returns expected blocks', () => {
+  const expected = Message()
+    .blocks(
+      Blocks.Section({ text: '*Agent Slack Bot Settings*' }).blockId('settings-header'),
+      Blocks.Actions().elements(Elements.Button({ text: 'Close', value: 'close' }))
+    )
+    .getBlocks() as KnownBlock[];
+  expect(getSettingsBlocks()).toEqual(expected);
+});

--- a/packages/agent-slack-bot/src/settings-block.ts
+++ b/packages/agent-slack-bot/src/settings-block.ts
@@ -1,0 +1,11 @@
+import { Message, Blocks, Elements } from 'slack-block-builder';
+import { KnownBlock } from '@slack/types';
+
+export function getSettingsBlocks(): KnownBlock[] {
+  return Message()
+    .blocks(
+      Blocks.Section({ text: '*Agent Slack Bot Settings*' }).blockId('settings-header'),
+      Blocks.Actions().elements(Elements.Button({ text: 'Close', value: 'close' }))
+    )
+    .getBlocks() as KnownBlock[];
+}


### PR DESCRIPTION
## Summary
- add `slack-block-builder` and `@slack/types`
- implement `getSettingsBlocks` using block builder
- test settings block builder output
- document plan for the Slack settings block

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6859f380d7bc832e82b142b4077f8676