### PR TITLE
Enable preset creation via Slack settings

### DIFF
--- a/packages/agent-slack-bot/docs/SLACK_BOT_CREATE_PRESET_PLAN.md
+++ b/packages/agent-slack-bot/docs/SLACK_BOT_CREATE_PRESET_PLAN.md
@@ -1,0 +1,31 @@
+# Slack Bot Preset Creation Plan
+
+## 요구사항
+
+- 슬랙 `/agentos-settings` 모달에서 Preset을 새로 생성할 수 있어야 한다.
+- Preset 이름과 System Prompt만 입력 받아 간단히 저장한다.
+- 저장 후에는 기존 preset 목록에 포함되어 선택할 수 있어야 한다.
+
+## 인터페이스 초안
+
+```ts
+// packages/agent-slack-bot/src/settings-block.ts
+export function getCreatePresetModal(): View;
+
+// packages/agent-slack-bot/src/index.ts
+app.action('preset-create', ...);
+app.view('preset-create-modal', ...);
+```
+
+## Todo 리스트
+
+- [ ] `getCreatePresetModal` 구현 및 테스트
+- [ ] settings modal에 'Create Preset' 버튼 추가
+- [ ] Slack action과 view submission 핸들러 추가
+- [ ] `pnpm lint`, `pnpm build`, `pnpm test` 실행
+
+## 작업 순서
+
+1. UI 블록 함수와 테스트 작성
+2. Slack 핸들러 로직 추가
+3. 린트/빌드/테스트 실행 후 커밋

--- a/packages/agent-slack-bot/docs/SLACK_BOT_MCP_AND_BRIDGE_PLAN.md
+++ b/packages/agent-slack-bot/docs/SLACK_BOT_MCP_AND_BRIDGE_PLAN.md
@@ -1,0 +1,31 @@
+# Slack Bot MCP & LLM Bridge Plan
+
+## 요구사항
+
+- Slack 설정에서 설치된 LLM Bridge 목록을 확인할 수 있어야 한다.
+- MCP 설정에서 websocket 또는 SSE 타입을 선택하고 URL을 입력할 수 있어야 한다.
+
+## 인터페이스 초안
+
+```ts
+// packages/core/src/common/utils/list-installed-llm-bridges.ts
+export function listInstalledLlmBridges(): string[];
+
+// packages/agent-slack-bot/src/settings-block.ts
+export function getMcpSettingsModal(): View;
+export function getCreatePresetModal(bridges: string[]): View;
+```
+
+## Todo 리스트
+
+- [ ] `listInstalledLlmBridges` core에 구현 및 테스트
+- [ ] `getCreatePresetModal` 확장: LLM Bridge 선택, MCP 타입/URL 입력 추가
+- [ ] MCP 설정 모달 UI 및 핸들러 추가
+- [ ] Slack 핸들러에서 LLM Bridge 목록 로딩 및 preset 저장 시 사용
+- [ ] `pnpm lint`, `pnpm build`, `pnpm test` 실행
+
+## 작업 순서
+
+1. 유틸 함수와 UI 블록 함수 작성 및 테스트
+2. Slack 액션과 뷰 핸들러 구현
+3. 린트/빌드/테스트 후 커밋

--- a/packages/agent-slack-bot/src/__tests__/create-preset-modal.test.ts
+++ b/packages/agent-slack-bot/src/__tests__/create-preset-modal.test.ts
@@ -1,0 +1,48 @@
+import { Modal, Blocks, Elements, Bits } from 'slack-block-builder';
+import { getCreatePresetModal } from '../settings-block';
+
+/** Basic shape of ModalBuilder.buildToObject() */
+interface View {
+  type: string;
+  title?: any;
+  submit?: any;
+  close?: any;
+  blocks: any[];
+  callback_id?: string;
+}
+
+test('getCreatePresetModal returns expected modal', () => {
+  const bridges = ['@llm-bridge/mock'];
+  const expected: View = Modal({ title: 'New Preset', submit: 'Save' })
+    .callbackId('preset-create-modal')
+    .blocks(
+      Blocks.Input({ label: 'Name' })
+        .blockId('name')
+        .element(Elements.TextInput().actionId('name')),
+      Blocks.Input({ label: 'System Prompt' })
+        .blockId('prompt')
+        .element(Elements.TextInput({ multiline: true }).actionId('prompt')),
+      Blocks.Input({ label: 'LLM Bridge' })
+        .blockId('bridge')
+        .element(
+          Elements.StaticSelect({ placeholder: 'Select Bridge' })
+            .actionId('bridge')
+            .options(bridges.map((b) => Bits.Option({ text: b, value: b })))
+        ),
+      Blocks.Input({ label: 'MCP Type' })
+        .blockId('mcpType')
+        .element(
+          Elements.StaticSelect({ placeholder: 'Select type' })
+            .actionId('mcpType')
+            .options([
+              Bits.Option({ text: 'WebSocket', value: 'websocket' }),
+              Bits.Option({ text: 'SSE', value: 'sse' }),
+            ])
+        ),
+      Blocks.Input({ label: 'MCP URL' })
+        .blockId('mcpUrl')
+        .element(Elements.TextInput().actionId('mcpUrl'))
+    )
+    .buildToObject() as View;
+  expect(getCreatePresetModal(bridges)).toEqual(expected);
+});

--- a/packages/agent-slack-bot/src/__tests__/mcp-settings-modal.test.ts
+++ b/packages/agent-slack-bot/src/__tests__/mcp-settings-modal.test.ts
@@ -1,0 +1,30 @@
+import { Modal, Blocks, Elements, Bits } from 'slack-block-builder';
+import { getMcpSettingsModal } from '../settings-block';
+
+interface View {
+  type: string;
+  blocks: any[];
+  callback_id?: string;
+  title?: any;
+  submit?: any;
+}
+
+test('getMcpSettingsModal returns expected modal', () => {
+  const expected: View = Modal({ title: 'MCP Settings', submit: 'Save' })
+    .callbackId('mcp-settings-modal')
+    .blocks(
+      Blocks.Input({ label: 'Type' })
+        .blockId('type')
+        .element(
+          Elements.StaticSelect({ placeholder: 'Select type' })
+            .actionId('type')
+            .options([
+              Bits.Option({ text: 'WebSocket', value: 'websocket' }),
+              Bits.Option({ text: 'SSE', value: 'sse' }),
+            ])
+        ),
+      Blocks.Input({ label: 'URL' }).blockId('url').element(Elements.TextInput().actionId('url'))
+    )
+    .buildToObject() as View;
+  expect(getMcpSettingsModal()).toEqual(expected);
+});

--- a/packages/agent-slack-bot/src/__tests__/settings-block.test.ts
+++ b/packages/agent-slack-bot/src/__tests__/settings-block.test.ts
@@ -20,6 +20,8 @@ test('getSettingsBlocks returns expected blocks', () => {
         Elements.StaticSelect({ placeholder: 'Select Preset' })
           .actionId('preset-change')
           .options(presets.map((p) => Bits.Option({ text: p.name, value: p.id }))),
+        Elements.Button({ text: 'Create Preset', value: 'open' }).actionId('preset-create'),
+        Elements.Button({ text: 'Edit MCP', value: 'open' }).actionId('mcp-settings'),
         Elements.Button({ text: 'Close', value: 'close' })
       )
     )

--- a/packages/agent-slack-bot/src/index.ts
+++ b/packages/agent-slack-bot/src/index.ts
@@ -3,9 +3,11 @@ import path from 'path';
 import { McpRegistry, FileBasedPresetRepository } from '@agentos/core';
 import { InMemoryLlmBridgeRegistry } from '@agentos/llm-bridge-runner';
 import { Message } from 'llm-bridge-spec';
-import { getSettingsBlocks } from './settings-block';
+import { getSettingsBlocks, getCreatePresetModal, getMcpSettingsModal } from './settings-block';
 import { PresetService } from './preset-service';
 import { FileBasedChannelPresetStore } from './channel-preset-store';
+import { listInstalledLlmBridges } from '@agentos/core';
+import { FileBasedMcpSettingsStore } from './mcp-settings-store';
 
 const app = new App({
   token: process.env.SLACK_BOT_TOKEN || '',
@@ -17,6 +19,9 @@ const channelPresetStore = new FileBasedChannelPresetStore(
   path.join(__dirname, '..', 'channel-presets')
 );
 const presetService = new PresetService(presetRepo, channelPresetStore);
+const mcpSettingsStore = new FileBasedMcpSettingsStore(
+  path.join(__dirname, '..', 'mcp-settings.json')
+);
 const userPresets = new Map<string, string>();
 
 function isGenericMessageEvent(msg: unknown): msg is GenericMessageEvent {
@@ -37,12 +42,61 @@ app.command('/agentos-settings', async ({ ack, body, client }) => {
   });
 });
 
+app.action('preset-create', async ({ ack, body, client }) => {
+  await ack();
+  const bridges = listInstalledLlmBridges();
+  await client.views.open({
+    trigger_id: body.trigger_id,
+    view: getCreatePresetModal(bridges),
+  });
+});
+
+app.action('mcp-settings', async ({ ack, body, client }) => {
+  await ack();
+  await client.views.open({
+    trigger_id: body.trigger_id,
+    view: getMcpSettingsModal(),
+  });
+});
+
 app.action('preset-change', async ({ ack, body, action }) => {
   await ack();
   const select = action as StaticSelectAction;
   if (select.selected_option) {
     userPresets.set(body.user.id, select.selected_option.value);
   }
+});
+
+app.view('preset-create-modal', async ({ ack, view, body }) => {
+  await ack();
+  const name = view.state.values['name']['name'].value as string;
+  const prompt = view.state.values['prompt']['prompt'].value as string;
+  const bridge = view.state.values['bridge']['bridge'].selected_option?.value as string;
+  const mcpType = view.state.values['mcpType']['mcpType'].selected_option?.value as
+    | 'websocket'
+    | 'sse';
+  const mcpUrl = view.state.values['mcpUrl']['mcpUrl'].value as string;
+  const id = name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  await presetService.create({
+    id,
+    name,
+    description: '',
+    author: body.user.id,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    version: '1.0.0',
+    systemPrompt: prompt,
+    enabledMcps: [],
+    llmBridgeName: bridge,
+    llmBridgeConfig: { mcpType, mcpUrl },
+  });
+});
+
+app.view('mcp-settings-modal', async ({ ack, view }) => {
+  await ack();
+  const type = view.state.values['type']['type'].selected_option?.value as 'websocket' | 'sse';
+  const url = view.state.values['url']['url'].value as string;
+  await mcpSettingsStore.save({ type, url });
 });
 
 app.message(async ({ message, say }) => {

--- a/packages/agent-slack-bot/src/mcp-settings-store.ts
+++ b/packages/agent-slack-bot/src/mcp-settings-store.ts
@@ -1,0 +1,30 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+export interface McpSettings {
+  type: 'websocket' | 'sse';
+  url: string;
+}
+
+export interface McpSettingsStore {
+  get(): Promise<McpSettings | null>;
+  save(settings: McpSettings): Promise<void>;
+}
+
+export class FileBasedMcpSettingsStore implements McpSettingsStore {
+  constructor(private readonly filePath: string) {}
+
+  async get(): Promise<McpSettings | null> {
+    try {
+      const raw = await fs.readFile(this.filePath, 'utf-8');
+      return JSON.parse(raw) as McpSettings;
+    } catch {
+      return null;
+    }
+  }
+
+  async save(settings: McpSettings): Promise<void> {
+    await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+    await fs.writeFile(this.filePath, JSON.stringify(settings, null, 2), 'utf-8');
+  }
+}

--- a/packages/agent-slack-bot/src/preset-service.ts
+++ b/packages/agent-slack-bot/src/preset-service.ts
@@ -16,6 +16,10 @@ export class PresetService {
     return this.repo.get(id);
   }
 
+  create(preset: Preset): Promise<void> {
+    return this.repo.create(preset);
+  }
+
   getActivePreset(channelId: string): Promise<string | null> {
     return this.channelStore.getPreset(channelId);
   }

--- a/packages/agent-slack-bot/src/settings-block.ts
+++ b/packages/agent-slack-bot/src/settings-block.ts
@@ -1,4 +1,4 @@
-import { Message, Blocks, Elements, Bits } from 'slack-block-builder';
+import { Message, Blocks, Elements, Bits, Modal } from 'slack-block-builder';
 import { KnownBlock } from '@slack/types';
 
 export interface PresetSummary {
@@ -16,8 +16,63 @@ export function getSettingsBlocks(presets: PresetSummary[]): KnownBlock[] {
         Elements.StaticSelect({ placeholder: 'Select Preset' })
           .actionId('preset-change')
           .options(presets.map((p) => Bits.Option({ text: p.name, value: p.id }))),
+        Elements.Button({ text: 'Create Preset', value: 'open' }).actionId('preset-create'),
+        Elements.Button({ text: 'Edit MCP', value: 'open' }).actionId('mcp-settings'),
         Elements.Button({ text: 'Close', value: 'close' })
       )
     )
     .getBlocks() as KnownBlock[];
+}
+
+export function getCreatePresetModal(bridges: string[]) {
+  return Modal({ title: 'New Preset', submit: 'Save' })
+    .callbackId('preset-create-modal')
+    .blocks(
+      Blocks.Input({ label: 'Name' })
+        .blockId('name')
+        .element(Elements.TextInput().actionId('name')),
+      Blocks.Input({ label: 'System Prompt' })
+        .blockId('prompt')
+        .element(Elements.TextInput({ multiline: true }).actionId('prompt')),
+      Blocks.Input({ label: 'LLM Bridge' })
+        .blockId('bridge')
+        .element(
+          Elements.StaticSelect({ placeholder: 'Select Bridge' })
+            .actionId('bridge')
+            .options(bridges.map((b) => Bits.Option({ text: b, value: b })))
+        ),
+      Blocks.Input({ label: 'MCP Type' })
+        .blockId('mcpType')
+        .element(
+          Elements.StaticSelect({ placeholder: 'Select type' })
+            .actionId('mcpType')
+            .options([
+              Bits.Option({ text: 'WebSocket', value: 'websocket' }),
+              Bits.Option({ text: 'SSE', value: 'sse' }),
+            ])
+        ),
+      Blocks.Input({ label: 'MCP URL' })
+        .blockId('mcpUrl')
+        .element(Elements.TextInput().actionId('mcpUrl'))
+    )
+    .buildToObject();
+}
+
+export function getMcpSettingsModal() {
+  return Modal({ title: 'MCP Settings', submit: 'Save' })
+    .callbackId('mcp-settings-modal')
+    .blocks(
+      Blocks.Input({ label: 'Type' })
+        .blockId('type')
+        .element(
+          Elements.StaticSelect({ placeholder: 'Select type' })
+            .actionId('type')
+            .options([
+              Bits.Option({ text: 'WebSocket', value: 'websocket' }),
+              Bits.Option({ text: 'SSE', value: 'sse' }),
+            ])
+        ),
+      Blocks.Input({ label: 'URL' }).blockId('url').element(Elements.TextInput().actionId('url'))
+    )
+    .buildToObject();
 }

--- a/packages/core/docs/LLM_BRIDGE_LISTING_PLAN.md
+++ b/packages/core/docs/LLM_BRIDGE_LISTING_PLAN.md
@@ -1,0 +1,25 @@
+# LLM Bridge Listing Utility Plan
+
+## Requirements
+- Provide a function in core to list installed LLM Bridge packages.
+- Read `package.json` dependencies and return names starting with `@llm-bridge/`.
+- Allow Slack bot and other packages to reuse this utility.
+
+## Interface Sketch
+```ts
+// packages/core/src/common/utils/list-installed-llm-bridges.ts
+export function listInstalledLlmBridges(baseDir?: string): string[];
+```
+
+## Todo
+- [ ] implement utility and unit test in core
+- [ ] export function from `core` index
+- [ ] remove Slack bot copy and update imports
+- [ ] update docs referencing old path
+- [ ] run `pnpm lint`, `pnpm build`, `pnpm test`
+
+## 작업 순서
+1. Create utility and test in core
+2. Update Slack bot to use new function and remove old file
+3. Adjust documentation
+4. Run lint, build, and test

--- a/packages/core/src/common/utils/__tests__/list-installed-llm-bridges.test.ts
+++ b/packages/core/src/common/utils/__tests__/list-installed-llm-bridges.test.ts
@@ -1,0 +1,14 @@
+import fs from 'fs';
+import path from 'path';
+import { listInstalledLlmBridges } from '../list-installed-llm-bridges';
+
+test('listInstalledLlmBridges reads dependencies', () => {
+  const dir = fs.mkdtempSync(path.join(__dirname, 'pkg-'));
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ dependencies: { '@llm-bridge/a': '1.0.0', other: '1.0.0' } })
+  );
+  const result = listInstalledLlmBridges(dir);
+  expect(result).toEqual(['@llm-bridge/a']);
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/packages/core/src/common/utils/list-installed-llm-bridges.ts
+++ b/packages/core/src/common/utils/list-installed-llm-bridges.ts
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Reads the package.json in the given directory and returns dependency names
+ * that appear to be LLM Bridge packages.
+ */
+export function listInstalledLlmBridges(baseDir = path.join(__dirname, '../../..')): string[] {
+  try {
+    const raw = fs.readFileSync(path.join(baseDir, 'package.json'), 'utf-8');
+    const pkg = JSON.parse(raw) as { dependencies?: Record<string, string> };
+    const deps = Object.keys(pkg.dependencies ?? {});
+    return deps.filter((name) => name.startsWith('@llm-bridge/'));
+  } catch {
+    return [];
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,3 +16,5 @@ export * from './mcp/mcp.registery';
 export * from './preset/preset';
 export * from './preset/preset.repository';
 export * from './preset/file-based-preset.repository';
+
+export * from './common/utils/list-installed-llm-bridges';


### PR DESCRIPTION
## Summary
- document plan for LLM bridge listing utility in core
- move `listInstalledLlmBridges` function and its tests to core
- update Slack bot to import the function from core
- clean up docs and add plan for the new utility

## Testing
- `pnpm lint`
- `pnpm build` *(fails: @agentos/gui build: `tsc && electron-builder`)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686483577dfc832e90f214c7bdb303a0