### PR TITLE
Fix tests by cleaning outputs and configuring ts-jest

### DIFF
--- a/packages/agent-slack-bot/tsconfig.json
+++ b/packages/agent-slack-bot/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "paths": {
+      "@agentos/core": ["../core/src"],
+      "llm-bridge-spec": ["../core/node_modules/llm-bridge-spec"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -6,5 +6,10 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.test.json',
+    },
+  },
   testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
 };

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- map `@agentos/core` in the Slack bot tsconfig so tests can find it
- remove compiled `.js` artifacts from tests by overriding tsconfig in `@agentos/core`
- configure `ts-jest` to use this new config

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6865d83f414c832ebc890fc39abd3de9