### PR TITLE
feat(lang): add JSON reviver utilities

### DIFF
--- a/packages/lang/src/fs/__tests__/JsonFileHandler.test.ts
+++ b/packages/lang/src/fs/__tests__/JsonFileHandler.test.ts
@@ -1,0 +1,21 @@
+import os from 'os';
+import path from 'path';
+import fs from 'fs/promises';
+import { JsonFileHandler } from '../JsonFileHandler';
+
+describe('JsonFileHandler revivers', () => {
+  it('revives ISO date strings to Date objects', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'json-handler-'));
+    const file = path.join(tmpDir, 'data.json');
+    const handler = new JsonFileHandler<{ createdAt: Date }>(file);
+    const date = new Date('2024-01-01T00:00:00.000Z');
+    await handler.write({ createdAt: date });
+    const read = await handler.read({ reviveDates: true });
+    expect(read.success).toBe(true);
+    if (read.success) {
+      expect(read.result.createdAt).toBeInstanceOf(Date);
+      expect(read.result.createdAt.toISOString()).toBe(date.toISOString());
+    }
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/packages/lang/src/json/__tests__/parser.test.ts
+++ b/packages/lang/src/json/__tests__/parser.test.ts
@@ -1,0 +1,23 @@
+import { safeJsonParseWithReviver, safeJsonParseWithDates } from '../parser';
+
+describe('JSON parser utilities', () => {
+  it('applies provided reviver', () => {
+    const json = '{"value":"42"}';
+    const res = safeJsonParseWithReviver<{ value: number }>(json, (key, value) =>
+      key === 'value' ? Number(value) : value,
+    );
+    expect(res.success).toBe(true);
+    expect(res.success && (res.result.value === 42)).toBe(true);
+  });
+
+  it('converts ISO strings to Date with safeJsonParseWithDates', () => {
+    const iso = '2024-01-01T00:00:00.000Z';
+    const json = `{"date":"${iso}"}`;
+    const res = safeJsonParseWithDates<{ date: Date }>(json);
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.result.date).toBeInstanceOf(Date);
+      expect(res.result.date.toISOString()).toBe(iso);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `safeJsonParseWithReviver` and `safeJsonParseWithDates` helpers to `@agentos/lang`
- support `reviver` and `reviveDates` options in `JsonFileHandler`
- cover new JSON reviver behavior with unit tests

## Testing
- `pnpm --filter @agentos/lang exec jest`


------
https://chatgpt.com/codex/tasks/task_e_68996ec76ba4832ea8534a3aee783080