### PR TITLE
GUI: LLM components → React Query (hooks, containers, ManagementView wiring)

### DIFF
--- a/apps/gui/docs/GUI_IMPLEMENTATION_PATTERNS.md
+++ b/apps/gui/docs/GUI_IMPLEMENTATION_PATTERNS.md
@@ -3,6 +3,7 @@
 This document defines mandatory patterns for GUI implementation to keep the codebase consistent, testable, and type-safe.
 
 ## 1) Container vs Presentational Components
+
 - Presentational components (e.g., `ModelManager`, `SubAgentManager`) receive all state and callbacks via props.
 - Containers (e.g., `ModelManagerContainer`, `PresetManagerContainer`) are responsible for:
   - Wiring React Query hooks/fetchers and ServiceContainer calls
@@ -10,6 +11,7 @@ This document defines mandatory patterns for GUI implementation to keep the code
   - Handling query invalidation, navigation side-effects, and cross-feature sync (e.g., `reloadAgents`)
 
 ## 2) React Query Keys & Invalidation
+
 - Centralize keys under a single module (e.g., `BRIDGE_QK`).
 - Mutations must invalidate the minimal set of keys to reflect new state:
   - Bridge switch: invalidate `current`, `ids`, `list`
@@ -17,23 +19,28 @@ This document defines mandatory patterns for GUI implementation to keep the code
 - Presentational components must not call `useQueryClient()` directly. Inject a refresh action via props instead.
 
 ## 3) Service Access & IPC Contracts
+
 - Do not access `ServiceContainer` directly in presentational components.
 - Containers or hooks manage IPC calls and map results into view models.
 - Keep Spec-aligned types at the boundary (e.g., `LlmManifest` from `llm-bridge-spec`).
 
 ## 4) Error/Loading/Empty UX
+
 - Use consistent skeletons/alerts.
 - Error and empty states are part of the presentational component props; containers determine when to render them.
 
 ## 5) Type Safety
+
 - No `any`. Use concrete types, generics, or `unknown` with guards.
 - Utilities (e.g., `toCapabilityLabels`) belong in `hooks/queries/*` or a shared utils module.
 
 ## 6) Composition Hooks
+
 - Prefer composite hooks to reduce N+1 fetch patterns (e.g., `useInstalledBridges` for ids→configs).
 - Keep query options (`staleTime`, `enabled`) near the hook to maintain behavior consistency.
 
 ## 7) App-Level Data Integration
+
 - Containers accept app-level actions/state through props (e.g., `reloadAgents`).
 - Avoid hidden global coupling; favor explicit props for cross-feature synchronization.
 

--- a/apps/gui/docs/GUI_IMPLEMENTATION_PATTERNS.md
+++ b/apps/gui/docs/GUI_IMPLEMENTATION_PATTERNS.md
@@ -1,0 +1,40 @@
+# GUI Implementation Patterns (Required)
+
+This document defines mandatory patterns for GUI implementation to keep the codebase consistent, testable, and type-safe.
+
+## 1) Container vs Presentational Components
+- Presentational components (e.g., `ModelManager`, `SubAgentManager`) receive all state and callbacks via props.
+- Containers (e.g., `ModelManagerContainer`, `PresetManagerContainer`) are responsible for:
+  - Wiring React Query hooks/fetchers and ServiceContainer calls
+  - Injecting callbacks (e.g., `onRefresh`, `onBridgeSwitch`) and domain actions
+  - Handling query invalidation, navigation side-effects, and cross-feature sync (e.g., `reloadAgents`)
+
+## 2) React Query Keys & Invalidation
+- Centralize keys under a single module (e.g., `BRIDGE_QK`).
+- Mutations must invalidate the minimal set of keys to reflect new state:
+  - Bridge switch: invalidate `current`, `ids`, `list`
+  - Register/unregister: invalidate `ids`, `list` (and `current` for unregister)
+- Presentational components must not call `useQueryClient()` directly. Inject a refresh action via props instead.
+
+## 3) Service Access & IPC Contracts
+- Do not access `ServiceContainer` directly in presentational components.
+- Containers or hooks manage IPC calls and map results into view models.
+- Keep Spec-aligned types at the boundary (e.g., `LlmManifest` from `llm-bridge-spec`).
+
+## 4) Error/Loading/Empty UX
+- Use consistent skeletons/alerts.
+- Error and empty states are part of the presentational component props; containers determine when to render them.
+
+## 5) Type Safety
+- No `any`. Use concrete types, generics, or `unknown` with guards.
+- Utilities (e.g., `toCapabilityLabels`) belong in `hooks/queries/*` or a shared utils module.
+
+## 6) Composition Hooks
+- Prefer composite hooks to reduce N+1 fetch patterns (e.g., `useInstalledBridges` for ids→configs).
+- Keep query options (`staleTime`, `enabled`) near the hook to maintain behavior consistency.
+
+## 7) App-Level Data Integration
+- Containers accept app-level actions/state through props (e.g., `reloadAgents`).
+- Avoid hidden global coupling; favor explicit props for cross-feature synchronization.
+
+By following these patterns, we ensure consistent, maintainable GUI code that cleanly separates data orchestration from presentation.

--- a/apps/gui/docs/MODEL_MANAGER_BRIDGE_INTEGRATION.md
+++ b/apps/gui/docs/MODEL_MANAGER_BRIDGE_INTEGRATION.md
@@ -16,6 +16,22 @@ This change refactors the GUI Model Manager to display installed LLM bridges fro
 2. For each ID, `getBridgeConfig(id)` returns the `LlmManifest`.
 3. `getCurrentBridge()` determines the active ID for status mapping.
 
+## React Query Hooks and Keys
+
+- Keys: `BRIDGE_QK`
+  - `current`: `['bridge','current']`
+  - `ids`: `['bridge','ids']`
+  - `config(id)`: `['bridge','config',id]`
+  - `list`: `['bridge','list']` (composed list: ids + manifests)
+
+- Hooks:
+  - `useInstalledBridges()` → loads composed list, caches under `BRIDGE_QK.list`
+  - `useCurrentBridge()` → active bridge
+  - `useSwitchBridge()` → invalidates `current`, `ids`, `list`
+  - `useRegisterBridge()` / `useUnregisterBridge()` → invalidates `ids`, `list` (and `current` for unregister)
+
+This enables ModelManager and settings screens to refresh consistently without manual wiring.
+
 ## Electron IPC Contract
 - `bridge.registerBridge(config: LlmManifest)`
 - `bridge.unregisterBridge(id: string)`
@@ -32,4 +48,3 @@ This change refactors the GUI Model Manager to display installed LLM bridges fro
 - UI code: `apps/gui/src/renderer/components/llm/ModelManager.tsx`
 - Plan: `apps/gui/plan/model-manager-bridge-integration.md`
 - Main IPC handlers: `apps/gui/src/main/services/bridge-ipc-handlers.ts`
-

--- a/apps/gui/docs/MODEL_MANAGER_BRIDGE_INTEGRATION.md
+++ b/apps/gui/docs/MODEL_MANAGER_BRIDGE_INTEGRATION.md
@@ -3,6 +3,7 @@
 This change refactors the GUI Model Manager to display installed LLM bridges from the Electron main process using the llm-bridge-spec manifest as the source of truth.
 
 ## What Changed
+
 - Instances tab now lists installed bridges from IPC (`bridge:get-ids` + `bridge:get-config`).
 - Active bridge shows as "online"; others show as "offline" (derived from `bridge:get-current`).
 - Capabilities badges are mapped from `LlmManifest.capabilities`:
@@ -12,6 +13,7 @@ This change refactors the GUI Model Manager to display installed LLM bridges fro
 - Empty state appears when no bridges are installed.
 
 ## How It Works
+
 1. `getBridgeIds()` returns installed bridge IDs (usually `manifest.name`).
 2. For each ID, `getBridgeConfig(id)` returns the `LlmManifest`.
 3. `getCurrentBridge()` determines the active ID for status mapping.
@@ -33,6 +35,7 @@ This change refactors the GUI Model Manager to display installed LLM bridges fro
 This enables ModelManager and settings screens to refresh consistently without manual wiring.
 
 ## Electron IPC Contract
+
 - `bridge.registerBridge(config: LlmManifest)`
 - `bridge.unregisterBridge(id: string)`
 - `bridge.switchBridge(id: string)`
@@ -41,10 +44,12 @@ This enables ModelManager and settings screens to refresh consistently without m
 - `bridge.getBridgeConfig(id: string): LlmManifest | null`
 
 ## Limitations (By Design)
+
 - Pricing/provider/endpoint/API keys are outside of `LlmManifest` and not displayed.
 - Usage/analytics are placeholder until usage tracking is wired in.
 
 ## Dev Notes
+
 - UI code: `apps/gui/src/renderer/components/llm/ModelManager.tsx`
 - Plan: `apps/gui/plan/model-manager-bridge-integration.md`
 - Main IPC handlers: `apps/gui/src/main/services/bridge-ipc-handlers.ts`

--- a/apps/gui/plan/LLM_REACT_QUERY_REFACTOR.md
+++ b/apps/gui/plan/LLM_REACT_QUERY_REFACTOR.md
@@ -1,0 +1,65 @@
+# 작업계획서: LLM 컴포넌트 React Query 리팩터링
+
+## Requirements
+
+### 성공 조건
+- [ ] `apps/gui/src/renderer/components/llm/*` 컴포넌트들이 React Query 기반 데이터 흐름으로 전환된다.
+- [ ] `ServiceContainer` 직접 호출/로컬 상태 기반 fetching 제거, 공용 hooks로 일원화된다.
+- [ ] 브릿지 목록/상세/활성 전환이 Query Key/Invalidation 규칙에 따라 일관되게 갱신된다.
+- [ ] 로딩/에러/빈 상태 UX가 명확히 표현된다.
+- [ ] 타입 안전(Manifest/Capabilities) 유지 및 any 사용 금지.
+
+### 사용 시나리오
+- [ ] ModelManager가 `useBridgeIds` + `useBridgeConfig`(배치)로 설치 목록과 Capabilities를 표시한다.
+- [ ] 현재 활성 브릿지는 `useCurrentBridge`로 상태가 유지되며, `useSwitchBridge` 성공 시 목록/상태가 갱신된다.
+- [ ] LLMSettings/LlmBridgeManager 등 관련 화면들도 동일한 hooks를 사용한다.
+
+### 제약 조건
+- [ ] 가격/프로바이더/사용량 등 Manifest 범위 밖의 정보는 표시하지 않는다(플레이스홀더 유지).
+- [ ] 설치/제거(등록/해제)는 IPC 지원 범위 내에서만 처리(없는 기능은 버튼 비활성/주석 처리).
+
+## Interface Sketch
+
+```ts
+// Query Keys (단일 소스)
+export const BRIDGE_QK = {
+  current: ['bridge', 'current'] as const,
+  ids: ['bridge', 'ids'] as const,
+  config: (id: string) => ['bridge', 'config', id] as const,
+  list: ['bridge', 'list'] as const, // 합성: ids + configs
+};
+
+// Existing hooks (apps/gui/src/renderer/hooks/queries/use-bridge.ts)
+useCurrentBridge(): UseQueryResult<{ id: string; config: LlmManifest } | null>
+useBridgeIds(): UseQueryResult<string[]>
+useBridgeConfig(id: string): UseQueryResult<LlmManifest | null>
+useSwitchBridge(): UseMutationResult<{ success: boolean }, unknown, string>
+
+// New composite hook
+useInstalledBridges(): {
+  data: { id: string; manifest: LlmManifest }[] | undefined;
+  isLoading: boolean;
+  error?: unknown;
+}
+// 구현: ids를 받아 useQueries(or Promise.all)로 각 config를 병렬 호출 → undefined/null 필터링
+// 성공 시 BRIDGE_QK.list에 캐시, switch/register/unregister 시 invalidate
+
+// Utility
+toCapabilityLabels(manifest: LlmManifest): string[]
+```
+
+## Todo
+- [ ] 공용 Query Keys 정리 및 `useInstalledBridges` 훅 추가 (hooks/queries/use-bridge.ts 또는 새 파일)
+- [ ] ModelManager: ServiceContainer 직접 호출 제거 → hooks 사용 + 상태/UX 갱신
+- [ ] LlmBridgeManager: 등록/목록/현재 상태 로딩을 hooks로 전환, 불필요 상태 제거
+- [ ] LLMSettings: 현 hooks 유지하되 invalidate 전략 점검(전환 시 list/current 무효화)
+- [ ] 에러/빈 상태/로딩 skeleton 통일 스타일 적용
+- [ ] 문서 업데이트 (apps/gui/docs/MODEL_MANAGER_BRIDGE_INTEGRATION.md 보강: hooks/키/무효화 규칙)
+- [ ] 간단 스냅샷 테스트 or 로직 단위 테스트(훅 레벨) 초안 (선택)
+
+## 작업 순서
+1. Hooks 확장: `useInstalledBridges` + Query Key 상수 정리 (완료 기준: ids+configs 병렬 로딩, 타입 안전)
+2. ModelManager 전환: hooks 기반 렌더링/검색/전환, 에러/빈 상태 반영 (완료 기준: 수동 fetch/remove 제거)
+3. LlmBridgeManager 전환: 등록/목록/현재 상태를 hooks로 (완료 기준: ServiceContainer 직접 호출 제거)
+4. LLMSettings 점검: 전환 후 invalidate 규칙 보강 (완료 기준: 전환 시 UI 일관 갱신)
+5. 문서화/정리: 문서/주석/가이드 보강, 필요 시 경량 테스트 추가

--- a/apps/gui/plan/LLM_REACT_QUERY_REFACTOR.md
+++ b/apps/gui/plan/LLM_REACT_QUERY_REFACTOR.md
@@ -3,6 +3,7 @@
 ## Requirements
 
 ### 성공 조건
+
 - [ ] `apps/gui/src/renderer/components/llm/*` 컴포넌트들이 React Query 기반 데이터 흐름으로 전환된다.
 - [ ] `ServiceContainer` 직접 호출/로컬 상태 기반 fetching 제거, 공용 hooks로 일원화된다.
 - [ ] 브릿지 목록/상세/활성 전환이 Query Key/Invalidation 규칙에 따라 일관되게 갱신된다.
@@ -10,11 +11,13 @@
 - [ ] 타입 안전(Manifest/Capabilities) 유지 및 any 사용 금지.
 
 ### 사용 시나리오
+
 - [ ] ModelManager가 `useBridgeIds` + `useBridgeConfig`(배치)로 설치 목록과 Capabilities를 표시한다.
 - [ ] 현재 활성 브릿지는 `useCurrentBridge`로 상태가 유지되며, `useSwitchBridge` 성공 시 목록/상태가 갱신된다.
 - [ ] LLMSettings/LlmBridgeManager 등 관련 화면들도 동일한 hooks를 사용한다.
 
 ### 제약 조건
+
 - [ ] 가격/프로바이더/사용량 등 Manifest 범위 밖의 정보는 표시하지 않는다(플레이스홀더 유지).
 - [ ] 설치/제거(등록/해제)는 IPC 지원 범위 내에서만 처리(없는 기능은 버튼 비활성/주석 처리).
 
@@ -49,6 +52,7 @@ toCapabilityLabels(manifest: LlmManifest): string[]
 ```
 
 ## Todo
+
 - [x] 공용 Query Keys 정리 및 `useInstalledBridges` 훅 추가 (hooks/queries/use-bridge.ts 또는 새 파일)
 - [x] ModelManager: ServiceContainer 직접 호출 제거 → hooks 사용 + 상태/UX 갱신
 - [x] LlmBridgeManager: 등록/목록/현재 상태 로딩을 hooks로 전환, 불필요 상태 제거
@@ -58,6 +62,7 @@ toCapabilityLabels(manifest: LlmManifest): string[]
 - [ ] 간단 스냅샷 테스트 or 로직 단위 테스트(훅 레벨) 초안 (선택)
 
 ## 작업 순서
+
 1. Hooks 확장: `useInstalledBridges` + Query Key 상수 정리 (완료 기준: ids+configs 병렬 로딩, 타입 안전)
 2. ModelManager 전환: hooks 기반 렌더링/검색/전환, 에러/빈 상태 반영 (완료 기준: 수동 fetch/remove 제거)
 3. LlmBridgeManager 전환: 등록/목록/현재 상태를 hooks로 (완료 기준: ServiceContainer 직접 호출 제거)

--- a/apps/gui/plan/LLM_REACT_QUERY_REFACTOR.md
+++ b/apps/gui/plan/LLM_REACT_QUERY_REFACTOR.md
@@ -49,12 +49,12 @@ toCapabilityLabels(manifest: LlmManifest): string[]
 ```
 
 ## Todo
-- [ ] 공용 Query Keys 정리 및 `useInstalledBridges` 훅 추가 (hooks/queries/use-bridge.ts 또는 새 파일)
-- [ ] ModelManager: ServiceContainer 직접 호출 제거 → hooks 사용 + 상태/UX 갱신
-- [ ] LlmBridgeManager: 등록/목록/현재 상태 로딩을 hooks로 전환, 불필요 상태 제거
-- [ ] LLMSettings: 현 hooks 유지하되 invalidate 전략 점검(전환 시 list/current 무효화)
-- [ ] 에러/빈 상태/로딩 skeleton 통일 스타일 적용
-- [ ] 문서 업데이트 (apps/gui/docs/MODEL_MANAGER_BRIDGE_INTEGRATION.md 보강: hooks/키/무효화 규칙)
+- [x] 공용 Query Keys 정리 및 `useInstalledBridges` 훅 추가 (hooks/queries/use-bridge.ts 또는 새 파일)
+- [x] ModelManager: ServiceContainer 직접 호출 제거 → hooks 사용 + 상태/UX 갱신
+- [x] LlmBridgeManager: 등록/목록/현재 상태 로딩을 hooks로 전환, 불필요 상태 제거
+- [x] LLMSettings: 현 hooks 유지하되 invalidate 전략 점검(전환 시 list/current 무효화)
+- [x] 에러/빈 상태/로딩 skeleton 통일 스타일 적용
+- [x] 문서 업데이트 (apps/gui/docs/MODEL_MANAGER_BRIDGE_INTEGRATION.md 보강: hooks/키/무효화 규칙)
 - [ ] 간단 스냅샷 테스트 or 로직 단위 테스트(훅 레벨) 초안 (선택)
 
 ## 작업 순서

--- a/apps/gui/src/renderer/components/layout/ManagementView.tsx
+++ b/apps/gui/src/renderer/components/layout/ManagementView.tsx
@@ -79,6 +79,7 @@ const ManagementView: React.FC<ManagementViewProps> = ({ navigation }) => {
     handleDeletePreset,
     getMentionableAgents,
     getActiveAgents,
+    reloadAgents,
   } = appData;
 
   // Create handlers that combine navigation and data operations (like design/App.tsx)
@@ -177,7 +178,7 @@ const ManagementView: React.FC<ManagementViewProps> = ({ navigation }) => {
         // Always render the React Query–backed container; it handles loading/empty states
         return <SubAgentManagerContainer onCreateAgent={handleStartCreateAgent} />;
       case 'models':
-        return <ModelManagerContainer />;
+        return <ModelManagerContainer reloadAgents={reloadAgents} />;
       case 'tools':
         return <MCPToolsManager />;
       case 'toolbuilder':

--- a/apps/gui/src/renderer/components/layout/ManagementView.tsx
+++ b/apps/gui/src/renderer/components/layout/ManagementView.tsx
@@ -1,9 +1,8 @@
 import { ArrowLeft, MessageSquare } from 'lucide-react';
 import React from 'react';
 import { Dashboard } from '../dashboard/Dashboard';
-import { ModelManager } from '../llm/ModelManager';
+import ModelManagerContainer from '../llm/ModelManagerContainer';
 import { MCPToolsManager } from '../mcp/McpToolManager';
-import { PresetManager } from '../preset/PresetManager';
 import SubAgentManagerContainer from '../sub-agent/SubAgentManagerContainer';
 import { ToolBuilder } from '../tool/ToolBuilder';
 import { Button } from '../ui/button';
@@ -18,12 +17,11 @@ import { getPageTitle } from '../../utils/appUtils';
 import { MCPToolCreate } from '../mcp/MCPToolCreate';
 import { PresetCreate } from '../preset/PresetCreate';
 import PresetDetailContainer from '../preset/PresetDetailContainer';
+import PresetManagerContainer from '../preset/PresetManagerContainer';
 import { RACPManager } from '../racp/RACPManager';
 import { SettingsManager } from '../settings/SettingManager';
-import { SubAgentCreate } from '../sub-agent/SubAgentCreate';
 import SubAgentCreateContainer from '../sub-agent/SubAgentCreateContainer';
 import { ToolBuilderCreate } from '../tool/ToolBuilderCreate';
-import PresetManagerContainer from '../preset/PresetManagerContainer';
 
 interface ManagementViewProps {
   navigation: UseAppNavigationReturn;
@@ -179,7 +177,7 @@ const ManagementView: React.FC<ManagementViewProps> = ({ navigation }) => {
         // Always render the React Query–backed container; it handles loading/empty states
         return <SubAgentManagerContainer onCreateAgent={handleStartCreateAgent} />;
       case 'models':
-        return <ModelManager />;
+        return <ModelManagerContainer />;
       case 'tools':
         return <MCPToolsManager />;
       case 'toolbuilder':

--- a/apps/gui/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/gui/src/renderer/components/layout/Sidebar.tsx
@@ -8,7 +8,6 @@ import {
   Plus,
   Settings,
   Shield,
-  Users,
   Wrench,
   Zap,
 } from 'lucide-react';

--- a/apps/gui/src/renderer/components/llm/LlmBridgeManager.tsx
+++ b/apps/gui/src/renderer/components/llm/LlmBridgeManager.tsx
@@ -2,7 +2,12 @@ import { Box, Button, HStack, Input, Select, Text, VStack } from '@chakra-ui/rea
 import type { LlmManifest } from 'llm-bridge-spec';
 import React, { useEffect, useState } from 'react';
 
-import { useBridgeIds, useCurrentBridge, useRegisterBridge, useUnregisterBridge } from '../../hooks/queries/use-bridge';
+import {
+  useBridgeIds,
+  useCurrentBridge,
+  useRegisterBridge,
+  useUnregisterBridge,
+} from '../../hooks/queries/use-bridge';
 
 export interface LlmBridgeManagerProps {
   onChange?(): void;

--- a/apps/gui/src/renderer/components/llm/ModelManager.tsx
+++ b/apps/gui/src/renderer/components/llm/ModelManager.tsx
@@ -18,37 +18,30 @@ import {
   Zap,
 } from 'lucide-react';
 import { useState } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { Card } from '../ui/card';
 import { Input } from '../ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { toCapabilityLabels } from '../../hooks/queries/normalize';
-import {
-  BRIDGE_QK,
-  useCurrentBridge,
-  useInstalledBridges,
-  useSwitchBridge,
-} from '../../hooks/queries/use-bridge';
+import { useCurrentBridge, useInstalledBridges, useSwitchBridge } from '../../hooks/queries/use-bridge';
 
 export interface ModelManagerProps {
   // Called after a successful bridge switch so outer containers can react
   onBridgeSwitch?: (bridgeId: string) => void | Promise<void>;
+  // Trigger refresh (invalidation) provided by container
+  onRefresh?: () => void;
 }
 
 export function ModelManager(props: ModelManagerProps = {}) {
   const [activeTab, setActiveTab] = useState('instances');
   const [searchQuery, setSearchQuery] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const queryClient = useQueryClient();
   const { data: installed = [], isLoading } = useInstalledBridges();
   const { data: currentBridge } = useCurrentBridge();
   const switchBridge = useSwitchBridge();
   const handleRefresh = () => {
-    queryClient.invalidateQueries({ queryKey: BRIDGE_QK.bridgeIds });
-    queryClient.invalidateQueries({ queryKey: BRIDGE_QK.bridgeList });
-    queryClient.invalidateQueries({ queryKey: BRIDGE_QK.currentBridge });
+    props.onRefresh && props.onRefresh();
   };
 
   const handleInstallModel = async (modelId: string) => {

--- a/apps/gui/src/renderer/components/llm/ModelManager.tsx
+++ b/apps/gui/src/renderer/components/llm/ModelManager.tsx
@@ -207,6 +207,17 @@ export function ModelManager() {
 
         <TabsContent value="instances" className="space-y-6">
           {/* Model Instances */}
+          {installed.length === 0 ? (
+            <Card className="p-6">
+              <div className="flex items-center gap-3">
+                <AlertCircle className="w-5 h-5 text-gray-500" />
+                <div>
+                  <h3 className="font-semibold">No installed bridges</h3>
+                  <p className="text-sm text-muted-foreground">Register a bridge and refresh.</p>
+                </div>
+              </div>
+            </Card>
+          ) : (
           <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
             {installed
               .map(({ id, manifest }) => ({
@@ -301,6 +312,7 @@ export function ModelManager() {
               </Card>
             ))}
           </div>
+          )}
         </TabsContent>
 
         <TabsContent value="marketplace" className="space-y-6">
@@ -326,11 +338,7 @@ export function ModelManager() {
                   <MessageSquare className="w-4 h-4 text-blue-600" />
                 </div>
                 <div>
-                  <p className="text-sm font-semibold">
-                    {formatNumber(
-                      modelInstances.reduce((sum, model) => sum + model.usage.requests, 0)
-                    )}
-                  </p>
+                  <p className="text-sm font-semibold">—</p>
                   <p className="text-xs text-muted-foreground">Total Requests</p>
                 </div>
               </div>
@@ -342,11 +350,7 @@ export function ModelManager() {
                   <Zap className="w-4 h-4 text-green-600" />
                 </div>
                 <div>
-                  <p className="text-sm font-semibold">
-                    {formatNumber(
-                      modelInstances.reduce((sum, model) => sum + model.usage.tokens, 0)
-                    )}
-                  </p>
+                  <p className="text-sm font-semibold">—</p>
                   <p className="text-xs text-muted-foreground">Total Tokens</p>
                 </div>
               </div>
@@ -358,11 +362,7 @@ export function ModelManager() {
                   <DollarSign className="w-4 h-4 text-purple-600" />
                 </div>
                 <div>
-                  <p className="text-sm font-semibold">
-                    {formatCurrency(
-                      modelInstances.reduce((sum, model) => sum + model.usage.cost, 0)
-                    )}
-                  </p>
+                  <p className="text-sm font-semibold">—</p>
                   <p className="text-xs text-muted-foreground">Total Cost</p>
                 </div>
               </div>
@@ -374,13 +374,7 @@ export function ModelManager() {
                   <Activity className="w-4 h-4 text-orange-600" />
                 </div>
                 <div>
-                  <p className="text-sm font-semibold">
-                    {(
-                      modelInstances.reduce((sum, model) => sum + model.performance.uptime, 0) /
-                      modelInstances.length
-                    ).toFixed(1)}
-                    %
-                  </p>
+                  <p className="text-sm font-semibold">—</p>
                   <p className="text-xs text-muted-foreground">Avg Uptime</p>
                 </div>
               </div>

--- a/apps/gui/src/renderer/components/llm/ModelManagerContainer.tsx
+++ b/apps/gui/src/renderer/components/llm/ModelManagerContainer.tsx
@@ -8,13 +8,15 @@ import { ModelManager } from './ModelManager';
  * future cross-feature reactions (e.g., agent/preset invalidation on bridge switch).
  */
 export const ModelManagerContainer: React.FC = () => {
-  const appData = useAppData();
-  // Currently, ModelManager manages its own React Query hooks for bridges.
-  // We keep this container to align with preset containers and to enable
-  // future interactions with appData (e.g., reload agents after switch).
-  void appData; // placeholder usage to acknowledge the binding
-  return <ModelManager />;
+  const { reloadAgents } = useAppData();
+
+  // Bridge change may influence agents/presets behavior; perform minimal sync.
+  const handleBridgeSwitch = async (_bridgeId: string) => {
+    // Reload agents so dependent views reflect the new bridge if necessary
+    await reloadAgents();
+  };
+
+  return <ModelManager onBridgeSwitch={handleBridgeSwitch} />;
 };
 
 export default ModelManagerContainer;
-

--- a/apps/gui/src/renderer/components/llm/ModelManagerContainer.tsx
+++ b/apps/gui/src/renderer/components/llm/ModelManagerContainer.tsx
@@ -1,21 +1,19 @@
 import React from 'react';
-import { useAppData } from '../../hooks/useAppData';
 import { ModelManager } from './ModelManager';
+
+export interface ModelManagerContainerProps {
+  reloadAgents: () => Promise<void>;
+}
 
 /**
  * Container that binds ModelManager to app-level data context (useAppData).
  * Keeps presentation (ModelManager) free of global concerns while allowing
  * future cross-feature reactions (e.g., agent/preset invalidation on bridge switch).
  */
-export const ModelManagerContainer: React.FC = () => {
-  const { reloadAgents } = useAppData();
-
-  // Bridge change may influence agents/presets behavior; perform minimal sync.
+export const ModelManagerContainer: React.FC<ModelManagerContainerProps> = ({ reloadAgents }) => {
   const handleBridgeSwitch = async (_bridgeId: string) => {
-    // Reload agents so dependent views reflect the new bridge if necessary
     await reloadAgents();
   };
-
   return <ModelManager onBridgeSwitch={handleBridgeSwitch} />;
 };
 

--- a/apps/gui/src/renderer/components/llm/ModelManagerContainer.tsx
+++ b/apps/gui/src/renderer/components/llm/ModelManagerContainer.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { ModelManager } from './ModelManager';
+import { BRIDGE_QK } from '../../hooks/queries/use-bridge';
 
 export interface ModelManagerContainerProps {
   reloadAgents: () => Promise<void>;
@@ -11,10 +13,18 @@ export interface ModelManagerContainerProps {
  * future cross-feature reactions (e.g., agent/preset invalidation on bridge switch).
  */
 export const ModelManagerContainer: React.FC<ModelManagerContainerProps> = ({ reloadAgents }) => {
+  const queryClient = useQueryClient();
+
+  const handleRefresh = () => {
+    queryClient.invalidateQueries({ queryKey: BRIDGE_QK.bridgeIds });
+    queryClient.invalidateQueries({ queryKey: BRIDGE_QK.bridgeList });
+    queryClient.invalidateQueries({ queryKey: BRIDGE_QK.currentBridge });
+  };
+
   const handleBridgeSwitch = async (_bridgeId: string) => {
     await reloadAgents();
   };
-  return <ModelManager onBridgeSwitch={handleBridgeSwitch} />;
+  return <ModelManager onBridgeSwitch={handleBridgeSwitch} onRefresh={handleRefresh} />;
 };
 
 export default ModelManagerContainer;

--- a/apps/gui/src/renderer/components/llm/ModelManagerContainer.tsx
+++ b/apps/gui/src/renderer/components/llm/ModelManagerContainer.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useAppData } from '../../hooks/useAppData';
+import { ModelManager } from './ModelManager';
+
+/**
+ * Container that binds ModelManager to app-level data context (useAppData).
+ * Keeps presentation (ModelManager) free of global concerns while allowing
+ * future cross-feature reactions (e.g., agent/preset invalidation on bridge switch).
+ */
+export const ModelManagerContainer: React.FC = () => {
+  const appData = useAppData();
+  // Currently, ModelManager manages its own React Query hooks for bridges.
+  // We keep this container to align with preset containers and to enable
+  // future interactions with appData (e.g., reload agents after switch).
+  void appData; // placeholder usage to acknowledge the binding
+  return <ModelManager />;
+};
+
+export default ModelManagerContainer;
+

--- a/apps/gui/src/renderer/components/llm/ModelManagerContainer.tsx
+++ b/apps/gui/src/renderer/components/llm/ModelManagerContainer.tsx
@@ -1,7 +1,12 @@
 import React, { useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { ModelManager, ModelManagerItem } from './ModelManager';
-import { BRIDGE_QK, useCurrentBridge, useInstalledBridges, useSwitchBridge } from '../../hooks/queries/use-bridge';
+import {
+  BRIDGE_QK,
+  useCurrentBridge,
+  useInstalledBridges,
+  useSwitchBridge,
+} from '../../hooks/queries/use-bridge';
 import { toCapabilityLabels } from '../../hooks/queries/normalize';
 
 export interface ModelManagerContainerProps {

--- a/apps/gui/src/renderer/hooks/queries/normalize.ts
+++ b/apps/gui/src/renderer/hooks/queries/normalize.ts
@@ -1,4 +1,5 @@
 import type { Message, MultiModalContent } from 'llm-bridge-spec';
+import type { LlmManifest } from 'llm-bridge-spec';
 
 export function normalizeToArrayContent(m: Message): MultiModalContent[] {
   const c = (m as any).content;
@@ -12,4 +13,16 @@ export function normalizeToArrayContent(m: Message): MultiModalContent[] {
     return [c as MultiModalContent];
   }
   return [{ contentType: 'text', value: String(c ?? '') }];
+}
+
+export function toCapabilityLabels(manifest: LlmManifest): string[] {
+  const labels: string[] = [];
+  const caps: any = (manifest as any).capabilities as any;
+  if (Array.isArray(caps?.modalities)) labels.push(...caps.modalities);
+  if (caps?.supportsToolCall) labels.push('tool-call');
+  if (caps?.supportsFunctionCall) labels.push('function-call');
+  if (caps?.supportsMultiTurn) labels.push('multi-turn');
+  if (caps?.supportsStreaming) labels.push('streaming');
+  if (caps?.supportsVision) labels.push('vision');
+  return Array.from(new Set(labels));
 }

--- a/apps/gui/src/renderer/hooks/queries/use-bridge.ts
+++ b/apps/gui/src/renderer/hooks/queries/use-bridge.ts
@@ -1,11 +1,13 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { ServiceContainer } from '../../../shared/ipc/service-container';
+import type { LlmManifest } from 'llm-bridge-spec';
 
 // Query Keys
-const QUERY_KEYS = {
+export const BRIDGE_QK = {
   currentBridge: ['bridge', 'current'] as const,
   bridgeIds: ['bridge', 'ids'] as const,
   bridgeConfig: (id: string) => ['bridge', 'config', id] as const,
+  bridgeList: ['bridge', 'list'] as const,
 } as const;
 
 // 현재 브릿지 조회
@@ -13,7 +15,7 @@ export const useCurrentBridge = () => {
   const bridgeService = ServiceContainer.getOrThrow('bridge');
 
   return useQuery({
-    queryKey: QUERY_KEYS.currentBridge,
+    queryKey: BRIDGE_QK.currentBridge,
     queryFn: () => bridgeService.getCurrentBridge(),
     staleTime: 60000, // 1분 - 브릿지 설정은 자주 변경되지 않음
   });
@@ -24,7 +26,7 @@ export const useBridgeIds = () => {
   const bridgeService = ServiceContainer.getOrThrow('bridge');
 
   return useQuery({
-    queryKey: QUERY_KEYS.bridgeIds,
+    queryKey: BRIDGE_QK.bridgeIds,
     queryFn: () => bridgeService.getBridgeIds(),
     staleTime: 300000, // 5분 - 브릿지 목록은 거의 변경되지 않음
   });
@@ -39,7 +41,10 @@ export const useSwitchBridge = () => {
     mutationFn: (bridgeId: string) => bridgeService.switchBridge(bridgeId),
     onSuccess: () => {
       // 현재 브릿지 정보 무효화
-      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.currentBridge });
+      queryClient.invalidateQueries({ queryKey: BRIDGE_QK.currentBridge });
+      // 목록 및 관련 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: BRIDGE_QK.bridgeList });
+      queryClient.invalidateQueries({ queryKey: BRIDGE_QK.bridgeIds });
       // 채팅 세션들도 영향받을 수 있으므로 무효화
       queryClient.invalidateQueries({ queryKey: ['chatSessions'] });
     },
@@ -51,9 +56,55 @@ export const useBridgeConfig = (bridgeId: string) => {
   const bridgeService = ServiceContainer.getOrThrow('bridge');
 
   return useQuery({
-    queryKey: QUERY_KEYS.bridgeConfig(bridgeId),
+    queryKey: BRIDGE_QK.bridgeConfig(bridgeId),
     queryFn: () => bridgeService.getBridgeConfig(bridgeId),
     enabled: !!bridgeId,
     staleTime: 300000, // 5분
+  });
+};
+
+// 설치된 브릿지 목록(Manifest 포함)을 한 번에 로드
+export const useInstalledBridges = () => {
+  const bridgeService = ServiceContainer.getOrThrow('bridge');
+
+  return useQuery<{ id: string; manifest: LlmManifest }[]>({
+    queryKey: BRIDGE_QK.bridgeList,
+    queryFn: async () => {
+      const ids = await bridgeService.getBridgeIds();
+      const manifests = await Promise.all(ids.map((id) => bridgeService.getBridgeConfig(id)));
+      const list: { id: string; manifest: LlmManifest }[] = [];
+      for (let i = 0; i < ids.length; i++) {
+        const m = manifests[i];
+        if (m) list.push({ id: ids[i], manifest: m });
+      }
+      return list;
+    },
+    staleTime: 300000,
+  });
+};
+
+// Bridge 등록/해제
+export const useRegisterBridge = () => {
+  const queryClient = useQueryClient();
+  const bridgeService = ServiceContainer.getOrThrow('bridge');
+  return useMutation({
+    mutationFn: (manifest: LlmManifest) => bridgeService.registerBridge(manifest),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: BRIDGE_QK.bridgeIds });
+      queryClient.invalidateQueries({ queryKey: BRIDGE_QK.bridgeList });
+    },
+  });
+};
+
+export const useUnregisterBridge = () => {
+  const queryClient = useQueryClient();
+  const bridgeService = ServiceContainer.getOrThrow('bridge');
+  return useMutation({
+    mutationFn: (id: string) => bridgeService.unregisterBridge(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: BRIDGE_QK.bridgeIds });
+      queryClient.invalidateQueries({ queryKey: BRIDGE_QK.bridgeList });
+      queryClient.invalidateQueries({ queryKey: BRIDGE_QK.currentBridge });
+    },
   });
 };

--- a/packages/core/src/agent/repository/__tests__/file-agent-metadata.repository.test.ts
+++ b/packages/core/src/agent/repository/__tests__/file-agent-metadata.repository.test.ts
@@ -106,11 +106,7 @@ describe('FileAgentMetadataRepository', () => {
     );
 
     await expect(
-      repo.update(
-        a1.id,
-        { description: 'second' },
-        { expectedVersion: a1.version }
-      )
+      repo.update(a1.id, { description: 'second' }, { expectedVersion: a1.version })
     ).rejects.toBeInstanceOf(CoreError);
 
     const final = await repo.get(a1.id);


### PR DESCRIPTION
## Summary
Refactors LLM-related GUI components to use React Query with unified keys and mutations, adds a container to align with preset architecture, and wires ManagementView to appData via the container.

### Changes
- Hooks
  - Add `BRIDGE_QK` keys, `useInstalledBridges`, `useRegisterBridge`, `useUnregisterBridge`
  - Strengthen invalidation on switch/register/unregister
  - `toCapabilityLabels(manifest)` utility
- Components
  - `ModelManager`: load via hooks (`useInstalledBridges`, `useCurrentBridge`, `useSwitchBridge`); unify empty/loading; analytics placeholders
  - `LlmBridgeManager`: move to hooks for list/current/register/unregister
  - `ModelManagerContainer`: appData-bound container
  - `ManagementView`: render `ModelManagerContainer`
- Docs: update `apps/gui/docs/MODEL_MANAGER_BRIDGE_INTEGRATION.md` with hooks/keys/invalidation
- Plan: update `apps/gui/plan/LLM_REACT_QUERY_REFACTOR.md`

### Rationale
- Mirrors preset architecture (container + hooks + presentational component)
- Centralizes cache keys and invalidation for consistent refresh semantics
- Prepares for future cross-feature interactions via appData

### Notes
- Usage/analytics remain placeholders until usage persistence lands in core
- Tests are optional and left pending in the plan
