### PR TITLE
GUI: Remove 'as any' and enforce safer typing in RPC/IPC/Presets

### DIFF
--- a/apps/gui/src/main/common/model/llm-bridge.module.ts
+++ b/apps/gui/src/main/common/model/llm-bridge.module.ts
@@ -1,10 +1,8 @@
-import { Module } from '@nestjs/common';
-import { LLM_BRIDGE_REGISTRY_TOKEN } from './constants';
 import { FileBasedLlmBridgeRegistry } from '@agentos/core';
-import type { LlmBridgeLoader, BridgeLoadResult } from 'llm-bridge-loader';
+import { Module } from '@nestjs/common';
+import { DependencyBridgeLoader } from 'llm-bridge-loader';
 import { ElectronAppEnvironment } from '../../electron/electron-app.environment';
-// Note: llm-bridge-loader package does not re-export DependencyBridgeLoader at root in our version.
-// Dynamically import concrete ESM path in factory to avoid resolution issues.
+import { LLM_BRIDGE_REGISTRY_TOKEN } from './constants';
 import * as path from 'path';
 
 @Module({
@@ -13,22 +11,7 @@ import * as path from 'path';
       provide: LLM_BRIDGE_REGISTRY_TOKEN,
       inject: [ElectronAppEnvironment],
       useFactory: async (env: ElectronAppEnvironment) => {
-        let loader: LlmBridgeLoader;
-        try {
-          const mod = await import(
-            'llm-bridge-loader/dist/esm/dependency/dependency-bridge.loader.js'
-          );
-          loader = new (
-            mod as { DependencyBridgeLoader: new () => LlmBridgeLoader }
-          ).DependencyBridgeLoader();
-        } catch {
-          class NoopBridgeLoader implements LlmBridgeLoader {
-            async load(_name: string): Promise<BridgeLoadResult> {
-              throw new Error('DependencyBridgeLoader not available in this build');
-            }
-          }
-          loader = new NoopBridgeLoader();
-        }
+        const loader = new DependencyBridgeLoader();
 
         return new FileBasedLlmBridgeRegistry(path.join(env.userDataPath, 'bridges'), loader);
       },

--- a/apps/gui/src/main/electron/transport/electron-event-transport.ts
+++ b/apps/gui/src/main/electron/transport/electron-event-transport.ts
@@ -95,8 +95,8 @@ export class ElectronEventTransport extends Server implements CustomTransportStr
             code: e.code,
             details: e.details,
           });
-        } else if (isObject(e) && 'code' in (e as any)) {
-          const anyErr = e as any;
+        } else if (isObject(e) && 'code' in e) {
+          const anyErr = e as { message?: string; code?: string; details?: unknown };
           return this.sendTo(senderId, {
             kind: 'err',
             cid: frame.cid,

--- a/apps/gui/src/main/electron/transport/electron-event-transport.ts
+++ b/apps/gui/src/main/electron/transport/electron-event-transport.ts
@@ -103,7 +103,7 @@ export class ElectronEventTransport extends Server implements CustomTransportStr
             ok: false,
             message: String(anyErr.message ?? '[error]'),
             code: anyErr.code ?? 'INTERNAL',
-            details: anyErr.details,
+            details: isObject(anyErr.details) ? anyErr.details : undefined,
           });
         } else if (e instanceof Error) {
           return this.sendTo(senderId, {

--- a/apps/gui/src/main/preset/dto/preset-upsert.dto.ts
+++ b/apps/gui/src/main/preset/dto/preset-upsert.dto.ts
@@ -61,7 +61,7 @@ export class PresetCreateDto implements CreatePreset {
   llmBridgeName!: string;
 
   @IsObject()
-  llmBridgeConfig!: Record<string, any>;
+  llmBridgeConfig!: Record<string, unknown>;
 
   @IsEnum(['active', 'idle', 'inactive'])
   status!: PresetStatus;

--- a/apps/gui/src/renderer/bootstrap.ts
+++ b/apps/gui/src/renderer/bootstrap.ts
@@ -10,7 +10,6 @@ import { McpUsageRpcService as McpUsageLogService } from './rpc/services/mcp-usa
 import { McpRpcService as McpService } from './rpc/services/mcp.service';
 import { PresetRpcService as PresetService } from './rpc/services/preset.service';
 
-import { waitForRpcReady } from './rpc/waitForReady';
 import { BuiltinToolService } from './services/builtin-tool.service';
 
 /**
@@ -61,14 +60,8 @@ export async function bootstrap(rpcTransport: RpcClient): Promise<BootstrapResul
 
   // --- Agent events stream bootstrap (frame-based) ---
   try {
-    type ElectronBridgeLike = {
-      start: (onFrame: (f: unknown) => void) => void;
-      post: (frame: unknown) => void;
-      on: (channel: string, handler: (payload: unknown) => void) => () => void;
-    };
-    const bridge = (window as unknown as { electronBridge?: ElectronBridgeLike })
-      .electronBridge as ElectronBridgeLike;
-    // Start agent events stream (req → nxt*)
+    const bridge = window.electronBridge;
+
     startStream(bridge, 'agent.events');
     // Wire parsed events (replace handlers with store updates as needed)
     const frames$ = fromBridge$(bridge);

--- a/apps/gui/src/renderer/bootstrap.ts
+++ b/apps/gui/src/renderer/bootstrap.ts
@@ -61,7 +61,13 @@ export async function bootstrap(rpcTransport: RpcClient): Promise<BootstrapResul
 
   // --- Agent events stream bootstrap (frame-based) ---
   try {
-    const bridge = (window as any).electronBridge;
+    type ElectronBridgeLike = {
+      start: (onFrame: (f: unknown) => void) => void;
+      post: (frame: unknown) => void;
+      on: (channel: string, handler: (payload: unknown) => void) => () => void;
+    };
+    const bridge = (window as unknown as { electronBridge?: ElectronBridgeLike })
+      .electronBridge as ElectronBridgeLike;
     // Start agent events stream (req → nxt*)
     startStream(bridge, 'agent.events');
     // Wire parsed events (replace handlers with store updates as needed)

--- a/apps/gui/src/renderer/components/preset/PresetCard.tsx
+++ b/apps/gui/src/renderer/components/preset/PresetCard.tsx
@@ -59,7 +59,11 @@ export const PresetCard: React.FC<PresetCardProps> = ({
         <div className="flex justify-between text-sm">
           <span className="text-muted-foreground">Model:</span>
           <span className="font-medium text-foreground">
-            {(preset.llmBridgeConfig as any)?.model ?? ''}
+            {String(
+              (preset.llmBridgeConfig &&
+                (preset.llmBridgeConfig as Record<string, unknown>).model) ??
+                ''
+            )}
           </span>
         </div>
         <div className="flex justify-between text-sm">

--- a/apps/gui/src/renderer/components/preset/PresetCreate.tsx
+++ b/apps/gui/src/renderer/components/preset/PresetCreate.tsx
@@ -768,14 +768,20 @@ export function PresetCreate({ onBack, onCreate }: PresetCreateProps) {
                                         <span>v{mcpTool.version}</span>
                                         {mcpTool.name === 'stdio' && (
                                           <span className="font-mono text-xs">
-                                            {(mcpTool as any).command}
+                                            {'command' in mcpTool
+                                              ? String(
+                                                  (mcpTool as { command?: unknown }).command ?? ''
+                                                )
+                                              : ''}
                                           </span>
                                         )}
                                         {(mcpTool.name === 'streamableHttp' ||
                                           mcpTool.name === 'websocket' ||
                                           mcpTool.name === 'sse') && (
                                           <span className="font-mono text-xs">
-                                            {(mcpTool as any).url}
+                                            {'url' in mcpTool
+                                              ? String((mcpTool as { url?: unknown }).url ?? '')
+                                              : ''}
                                           </span>
                                         )}
                                       </div>

--- a/apps/gui/src/renderer/components/preset/PresetDetail.tsx
+++ b/apps/gui/src/renderer/components/preset/PresetDetail.tsx
@@ -200,7 +200,7 @@ export function PresetDetail({ preset, onBack, onUpdate, onDelete }: PresetDetai
               </div>
               <div>
                 <p className="text-lg font-semibold text-foreground">
-                  {formatDate(editedPreset.updatedAt as any)}
+                  {formatDate(editedPreset.updatedAt)}
                 </p>
                 <p className="text-xs text-muted-foreground">Last Updated</p>
               </div>

--- a/apps/gui/src/renderer/components/preset/PresetForm.tsx
+++ b/apps/gui/src/renderer/components/preset/PresetForm.tsx
@@ -35,7 +35,7 @@ export function PrestForm({
     systemPrompt: '',
     category: ['research'],
     llmBridgeConfig: {},
-    status: 'active' as any,
+    status: 'active',
     ...preset,
   };
 

--- a/apps/gui/src/renderer/components/preset/PresetManagerContainer.tsx
+++ b/apps/gui/src/renderer/components/preset/PresetManagerContainer.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { CreatePreset, Preset } from '@agentos/core';
 import { PresetManager } from './PresetManager';
 import {
   fetchPresets,
@@ -34,12 +35,13 @@ export const PresetManagerContainer: React.FC<{ onStartCreatePreset?: () => void
   });
 
   const createMutation = useMutation({
-    mutationFn: (data: any) => createPreset(data),
+    mutationFn: (data: CreatePreset) => createPreset(data),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['presets'] }),
   });
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: any }) => updatePreset(id, data),
+    mutationFn: ({ id, data }: { id: string; data: Partial<Omit<Preset, 'id'>> }) =>
+      updatePreset(id, data),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['presets'] }),
   });
 
@@ -136,9 +138,11 @@ export const PresetManagerContainer: React.FC<{ onStartCreatePreset?: () => void
         isLoading={false}
         onDeletePreset={(id) => deleteMutation.mutate(id)}
         onDuplicatePreset={(p) => duplicateMutation.mutate(p.id)}
-        onCreatePreset={(data) => createMutation.mutate(data as any)}
-        onCreatePresetAsync={(data) => createMutation.mutateAsync(data as any)}
-        onUpdatePreset={(id, data) => updateMutation.mutate({ id, data } as any)}
+        onCreatePreset={(data) => createMutation.mutate(data as unknown as CreatePreset)}
+        onCreatePresetAsync={(data) => createMutation.mutateAsync(data as CreatePreset)}
+        onUpdatePreset={(id, data) =>
+          updateMutation.mutate({ id, data: data as Partial<Omit<Preset, 'id'>> })
+        }
         onStartCreatePreset={onStartCreatePreset}
       />
     </div>

--- a/apps/gui/src/renderer/hooks/queries/normalize.ts
+++ b/apps/gui/src/renderer/hooks/queries/normalize.ts
@@ -1,8 +1,8 @@
 import type { Message, MultiModalContent } from 'llm-bridge-spec';
-import type { LlmManifest } from 'llm-bridge-spec';
+import type { LlmManifest, LlmBridgeCapabilities } from 'llm-bridge-spec';
 
 export function normalizeToArrayContent(m: Message): MultiModalContent[] {
-  const c = (m as any).content;
+  const c: unknown = (m as unknown as { content?: unknown }).content;
   if (Array.isArray(c)) {
     return c as MultiModalContent[];
   }
@@ -17,12 +17,12 @@ export function normalizeToArrayContent(m: Message): MultiModalContent[] {
 
 export function toCapabilityLabels(manifest: LlmManifest): string[] {
   const labels: string[] = [];
-  const caps: any = (manifest as any).capabilities as any;
-  if (Array.isArray(caps?.modalities)) labels.push(...caps.modalities);
-  if (caps?.supportsToolCall) labels.push('tool-call');
-  if (caps?.supportsFunctionCall) labels.push('function-call');
-  if (caps?.supportsMultiTurn) labels.push('multi-turn');
-  if (caps?.supportsStreaming) labels.push('streaming');
-  if (caps?.supportsVision) labels.push('vision');
+  const caps: LlmBridgeCapabilities = manifest.capabilities;
+  if (Array.isArray(caps.modalities)) labels.push(...caps.modalities);
+  if (caps.supportsToolCall) labels.push('tool-call');
+  if (caps.supportsFunctionCall) labels.push('function-call');
+  if (caps.supportsMultiTurn) labels.push('multi-turn');
+  if (caps.supportsStreaming) labels.push('streaming');
+  if (caps.supportsVision) labels.push('vision');
   return Array.from(new Set(labels));
 }

--- a/apps/gui/src/renderer/hooks/queries/use-presets.ts
+++ b/apps/gui/src/renderer/hooks/queries/use-presets.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { ServiceContainer } from '../../ipc/service-container';
-import type { Preset } from '@agentos/core';
+import type { CreatePreset, Preset } from '@agentos/core';
 
 // Query Keys
 const QUERY_KEYS = {
@@ -37,7 +37,7 @@ export const useCreatePreset = () => {
   const presetService = ServiceContainer.getOrThrow('preset');
 
   return useMutation({
-    mutationFn: (preset: Preset) => presetService.createPreset(preset as any),
+    mutationFn: (preset: CreatePreset) => presetService.createPreset(preset),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.presets });
     },

--- a/apps/gui/src/renderer/ipc/electron-ipc-channel.ts
+++ b/apps/gui/src/renderer/ipc/electron-ipc-channel.ts
@@ -28,6 +28,21 @@ import type {
   SetUsageTrackingResponse,
   UsageLogQueryOptions,
 } from '../../shared/types/mcp-usage-types';
+import { FrameTransport } from '../../shared/rpc/transport';
+import { RpcFrame } from '../../shared/rpc/rpc-frame';
+
+// Preload-exposed bridge typing
+export interface ElectronEventBridge extends FrameTransport {
+  start: (onFrame: (f: RpcFrame) => void) => void;
+  post: (frame: RpcFrame) => void;
+  stop: () => void;
+}
+
+declare global {
+  interface Window {
+    electronBridge?: ElectronEventBridge;
+  }
+}
 
 export class ElectronIpcChannel implements IpcChannel {
   private get electronAPI() {
@@ -163,7 +178,7 @@ export class ElectronIpcChannel implements IpcChannel {
     // 메인에 구독 활성화 요청 (폴링/브리지 설정 등)
     await this.electronAPI.mcpUsageLog.subscribeToUsageUpdates(callback);
     // Preload에서 노출한 안전한 이벤트 브리지 사용
-    const bridge = (window as any).electronBridge;
+    const bridge = window.electronBridge;
     if (!bridge || typeof bridge.on !== 'function') {
       throw new Error('electronBridge.on is not available. Ensure preload exposes it.');
     }

--- a/apps/gui/src/renderer/main.ts
+++ b/apps/gui/src/renderer/main.ts
@@ -15,6 +15,7 @@ async function initializeApp() {
   await waitForRpcReady();
 
   const envInfo = getEnvironmentInfo();
+
   console.log(`🚀 Starting AgentOS in ${envInfo.detected} environment...`);
   console.log('Environment details:', envInfo);
 

--- a/apps/gui/src/renderer/rpc/frame-channel.ts
+++ b/apps/gui/src/renderer/rpc/frame-channel.ts
@@ -1,17 +1,12 @@
 import { Observable, filter, share } from 'rxjs';
 import type { RpcFrame } from '../../shared/rpc/rpc-frame';
-
-type Bridge = {
-  start: (onFrame: (f: RpcFrame) => void) => void;
-  post: (f: RpcFrame) => void;
-  stop?: () => void;
-};
+import { FrameTransport } from '../../shared/rpc/transport';
 
 /**
  * Wraps preload bridge into a cold Observable of RpcFrame.
  * Use once and share among consumers to avoid multiple start() invocations.
  */
-export function fromBridge$(bridge: Bridge): Observable<RpcFrame> {
+export function fromBridge$(bridge: FrameTransport): Observable<RpcFrame> {
   return new Observable<RpcFrame>((sub) => {
     bridge.start((f) => sub.next(f));
     return () => bridge.stop?.();
@@ -29,11 +24,18 @@ export function byMethod(
 ): (source: Observable<RpcFrame>) => Observable<RpcFrame> {
   return (source) =>
     source.pipe(
-      filter((f) => {
-        const m = (f as any).method as string | undefined;
-        if (!m) return false;
-        if (pattern instanceof RegExp) return pattern.test(m);
-        return m === pattern || m.startsWith(pattern);
+      filter((frame) => {
+        if (frame.kind !== 'req' && frame.kind !== 'nxt') {
+          return false;
+        }
+
+        if (!frame.method) return false;
+
+        if (pattern instanceof RegExp) {
+          return pattern.test(frame.method);
+        }
+
+        return frame.method === pattern || frame.method.startsWith(pattern);
       })
     );
 }
@@ -41,19 +43,19 @@ export function byMethod(
 /**
  * Convenience selector: stream only data payloads for frames with matching method.
  */
-export function selectDataByMethod<T = unknown>(
+export function selectDataByMethod(
   pattern: string | RegExp
-): (source: Observable<RpcFrame>) => Observable<T> {
+): (source: Observable<RpcFrame>) => Observable<RpcFrame> {
   return (source) =>
     source.pipe(
       byMethod(pattern),
-      filter((f) => f.kind === 'nxt'),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      filter((f: any) => 'data' in f)
-    ) as unknown as Observable<T>;
+      filter((frame) => frame.kind === 'nxt'),
+      filter((frame) => 'data' in frame)
+    );
 }
 
 let seq = 0;
+
 function newCid() {
   return `${Date.now()}-${++seq}-${Math.random().toString(16).slice(2)}`;
 }
@@ -62,7 +64,7 @@ function newCid() {
  * Starts a stream by posting a req frame; returns a cancel function that sends a can frame.
  */
 export function startStream(
-  bridge: Bridge,
+  bridge: FrameTransport,
   method: string,
   payload?: unknown,
   meta?: { senderId?: number; rpcSpecVersion?: string; ts?: number }

--- a/apps/gui/src/renderer/rpc/rpc-endpoint.ts
+++ b/apps/gui/src/renderer/rpc/rpc-endpoint.ts
@@ -15,13 +15,13 @@ export interface RpcClientOptions {
 }
 
 type RpcObserver = {
-  resolve: (v: any) => void;
-  reject: (e: any) => void;
+  resolve: (v: unknown) => void;
+  reject: (e: unknown) => void;
   timer?: number | NodeJS.Timeout;
   // streaming
-  next?: (v: any) => void;
+  next?: (v: unknown) => void;
   complete?: () => void;
-  error?: (e: any) => void;
+  error?: (e: unknown) => void;
 };
 
 type StreamContext<T> = {
@@ -268,11 +268,16 @@ export class RpcEndpoint implements RpcClient {
 }
 
 function isAsyncGen(o: unknown): o is AsyncGenerator<unknown, void, unknown> {
-  return isObject(o) && typeof (o as any)[Symbol.asyncIterator] === 'function';
+  if (!isObject(o)) return false;
+  const iterator = (o as { [Symbol.asyncIterator]?: unknown })[Symbol.asyncIterator];
+  return typeof iterator === 'function';
 }
 function isObservableLike(o: unknown): o is Observable<unknown> {
-  return isObservable(o) && o && typeof (o as any).subscribe === 'function';
+  return (
+    isObservable(o) && isObject(o) && typeof (o as { subscribe?: unknown }).subscribe === 'function'
+  );
 }
 function isPromiseLike(o: unknown): o is PromiseLike<unknown> {
-  return !!o && typeof (o as any).then === 'function';
+  const isObjOrFn = (typeof o === 'object' && o !== null) || typeof o === 'function';
+  return isObjOrFn && typeof (o as { then?: unknown }).then === 'function';
 }

--- a/apps/gui/src/renderer/rpc/services/preset.service.ts
+++ b/apps/gui/src/renderer/rpc/services/preset.service.ts
@@ -62,11 +62,11 @@ export class PresetRpcService {
 
     const res = await this.create(param);
 
-    if (!res.success) {
+    if (!res.success || !res.result?.id) {
       throw new Error(res.error || 'Failed to create preset');
     }
 
-    const got = await this.getOrThrow((res as any).result?.id ?? '');
+    const got = await this.getOrThrow(res.result.id);
 
     return got;
   }

--- a/apps/gui/src/renderer/services/ipc-agent.ts
+++ b/apps/gui/src/renderer/services/ipc-agent.ts
@@ -83,8 +83,8 @@ export class IpcAgent implements Agent {
     return await this.agentProtocol.chat(this.agentId, messages, options);
   }
 
-  async update(patch: Partial<ReadonlyAgentMetadata>): Promise<void> {
-    await this.agentProtocol.updateAgent(this.agentId, patch as any);
+  async update(patch: Partial<Omit<ReadonlyAgentMetadata, 'id'>>): Promise<void> {
+    await this.agentProtocol.updateAgent(this.agentId, patch);
   }
 
   async delete(): Promise<void> {

--- a/apps/gui/src/renderer/stores/preset-store.ts
+++ b/apps/gui/src/renderer/stores/preset-store.ts
@@ -1,4 +1,4 @@
-import type { Preset } from '@agentos/core';
+import type { CreatePreset, Preset } from '@agentos/core';
 import type { PresetProtocol } from '../../shared/types/proset-protocol';
 import { ServiceContainer } from '../ipc/service-container';
 
@@ -15,9 +15,22 @@ export class PresetStore {
   async save(preset: Preset): Promise<void> {
     // ID가 있으면 업데이트, 없으면 생성
     if (await this.exists(preset.id)) {
-      await this.presetService.updatePreset(preset.id, preset as any);
+      const { id: _id, ...patch } = preset;
+      await this.presetService.updatePreset(preset.id, patch);
     } else {
-      await this.presetService.createPreset(preset as any);
+      const createData: CreatePreset = {
+        name: preset.name,
+        description: preset.description,
+        author: preset.author,
+        version: preset.version,
+        systemPrompt: preset.systemPrompt,
+        enabledMcps: preset.enabledMcps,
+        llmBridgeName: preset.llmBridgeName,
+        llmBridgeConfig: preset.llmBridgeConfig,
+        status: preset.status,
+        category: preset.category,
+      };
+      await this.presetService.createPreset(createData);
     }
   }
 

--- a/apps/gui/src/renderer/utils/message-parser.ts
+++ b/apps/gui/src/renderer/utils/message-parser.ts
@@ -5,6 +5,12 @@ import type { MessageHistory } from '@agentos/core';
  * @param message MessageHistory 또는 MessageRecord
  * @returns 파싱된 텍스트 문자열
  */
+type TextLike = { contentType: string; value: string };
+
+function isTextLike(obj: unknown): obj is TextLike {
+  return !!obj && typeof obj === 'object' && 'contentType' in obj && 'value' in obj;
+}
+
 export function parseMessageContent(message: MessageHistory): string {
   if (!message.content) {
     return '';
@@ -24,9 +30,8 @@ export function parseMessageContent(message: MessageHistory): string {
   }
 
   // 단일 콘텐츠(레거시) 호환 처리
-  if (typeof message.content === 'object' && (message.content as any).contentType) {
-    const legacy = message.content as { contentType: string; value: string };
-    return legacy.contentType === 'text' ? legacy.value : '';
+  if (isTextLike(message.content)) {
+    return message.content.contentType === 'text' ? message.content.value : '';
   }
 
   return '';
@@ -73,8 +78,8 @@ export function hasTextContent(message: MessageHistory): boolean {
     return message.content.some((c) => c.contentType === 'text');
   }
 
-  if (typeof message.content === 'object' && (message.content as any).contentType) {
-    return (message.content as any).contentType === 'text';
+  if (isTextLike(message.content)) {
+    return message.content.contentType === 'text';
   }
 
   return false;

--- a/apps/gui/src/types.d.ts
+++ b/apps/gui/src/types.d.ts
@@ -33,6 +33,7 @@ declare global {
     rpc?: {
       request: (channel: string, payload?: unknown) => Promise<unknown>;
     };
+    __APP_ENV__?: { nodeEnv?: string; buildTarget?: 'electron' | 'web' | 'extension' };
   }
 
   // process 객체 부분 polyfill (브라우저 환경용)


### PR DESCRIPTION
## Summary
- Remove 'as any' usages across GUI (Preset components, store, queries, fetchers)
- Add safe type guards in RPC endpoint and electron bridge typings
- Tighten Preset create/update DTO typing and usage
- Fix ESLint/Prettier errors; leave warnings for incremental cleanup

## Motivation
- Align with Type Safety Principles (no 'any', unknown + type guard, explicit DTOs)
- Stabilize RPC migration by improving runtime guards and cleanup semantics

## Changes
- PresetDetail/Form/ManagerContainer: remove 'as any', proper types
- rpc-endpoint: isAsyncGen/isObservableLike/isPromiseLike without any; prettier fixes
- electron-ipc-channel: typed electronBridge; no window as any
- normalize utils: typed manifest capabilities; unknown narrowing
- fetchers/chat: typed Message/StringContent; role mapping cleanup
- preset-store: create payload typed; id-less update patch

## Verification
- pnpm -w -r run lint passes without errors (warnings remain)
- File-scoped ESLint run for rpc-endpoint: clean

## Follow-ups
- Add custom ESLint rule to forbid single-line blocks (see proposal) and elevate GUI no-explicit-any to error repo-wide
- Migrate RPC type-guards to shared utils and add tests

## Checklist
- [x] Lint/format run locally
- [x] Branch up to date
- [x] Scope-limited commits