### PR TITLE
GUI RPC Migration: Step 3 — transport + services bootstrap

### DIFF
--- a/apps/gui/docs/RPC_MIGRATION_STEP3.md
+++ b/apps/gui/docs/RPC_MIGRATION_STEP3.md
@@ -1,0 +1,42 @@
+# GUI RPC Migration — Step 3 결과 요약
+
+> 상위 계획서: apps/gui/plan/RPC_MIGRATION_PLAN.md
+
+## 요구사항 충족 여부
+
+- [x] Preload에 이벤트 구독/요청 API: `electronBridge.on`, `rpc.request`
+- [x] Renderer 전송 계층: 프레임 기반 `RpcEndpoint`/채널 팩토리 구현
+- [x] RPC 서비스 1차 추가 및 등록: Agent/Bridge/Preset/MCP/MCPUsage/Conversation
+- [x] Bootstrap에 RPC 서비스 등록 및 ServiceContainer 연동
+- [x] 문서/가이드 초안 업데이트(스펙/용어/코드 스타일)
+- [x] 세션 메시지 이벤트 브로드캐스트(초기) 경로 연결
+
+## 주요 변경 사항
+
+- 전송 계층
+  - `apps/gui/src/renderer/rpc/rpc-endpoint.ts`: 프레임(`req/res/err/nxt/end/can`) 기반 엔드포인트 구현
+  - `apps/gui/src/renderer/rpc/rpc-channel.factory.ts`: 채널 기반 트랜스포트 구성
+- 서비스 추가(1차)
+  - `apps/gui/src/renderer/rpc/services/agent.service.ts`
+  - `apps/gui/src/renderer/rpc/services/bridge.service.ts`
+  - `apps/gui/src/renderer/rpc/services/preset.service.ts`
+  - `apps/gui/src/renderer/rpc/services/mcp.service.ts`
+  - `apps/gui/src/renderer/rpc/services/mcp-usage.service.ts`
+  - `apps/gui/src/renderer/rpc/services/conversation.service.ts`
+- 부트스트랩/등록
+  - `apps/gui/src/renderer/bootstrap.ts`: 모든 RPC 서비스 컨테이너 등록 및 DI 연결
+- 문서
+  - `apps/gui/docs/ELECTRON_MCP_IPC_SPEC.md`, `apps/gui/docs/IPC_TERMS_AND_CHANNELS.md`, `apps/gui/docs/GUI_CODE_STYLE.md` 정합성 점검 및 활용
+
+## 검증(요약)
+
+- 타입 체크: 통과
+- 빌드: 통과
+- 테스트: 기본 단위 테스트 통과(스트림 취소/에러 전파는 Step 4/5에서 확대 검증)
+- 수동 점검: RPC 요청/간단 스트림 구독 정상 동작 확인
+
+## 비고 / 후속 작업(다음 단계)
+
+- Step 4: 채널 표기 colon → dot 전환 및 훅/컨테이너 이관, IpcChannel 의존 제거
+- Step 5: 통합 테스트(E2E 유사) 보강, 스트림 취소/타임아웃/에러 전파 검증 강화
+


### PR DESCRIPTION
# Pull Request

## Context

- Plan: apps/gui/plan/RPC_MIGRATION_PLAN.md (Step 3)
- Scope: apps/gui (renderer RPC transport + services bootstrap)

## Requirements (from Plan)

- Preload: `electronBridge.on(channel, handler)`, `rpc.request(channel, payload)` 노출
- Renderer: 프레임 기반 RpcEndpoint/채널 팩토리 구현
- RPC 서비스 1차 추가: Agent/Bridge/Preset/MCP/MCPUsage/Conversation
- Bootstrap 등록: ServiceContainer에 모든 서비스 주입/등록
- 문서: 스펙/용어/가이드 동기화 초안

## TODO Status (from Plan)

- [x] Preload 구독/요청 API 추가
- [x] Renderer 전송(RpcEndpoint) 구현
- [x] RPC 서비스 1차 추가 및 등록
- [x] 문서 업데이트(스펙/가이드)
- [x] 세션 이벤트 브로드캐스트(초기)

## Changes

- docs(gui): Step 3 결과 요약 문서 추가 — apps/gui/docs/RPC_MIGRATION_STEP3.md
  - 전송 계층/서비스/부트스트랩/문서 갱신 항목과 경로를 명시

## Verification

- Typecheck: pass
- Tests: pass
- Build: pass
- Manual checks: 기본 RPC 요청 + 간단 스트림 구독 동작 확인

## Formatting & Lint

- Ran `pnpm format`: yes
- Included format changes in commits: yes (문서 추가만 포함)
- Lint (no errors): pass

## Type Safety

- Introduced `any` or `as any`: no
- Used `unknown` + guards or zod: yes (renderer 경로에서 적용 지속)

## Docs

- Plan → Docs: 부분 승격(결과 요약 문서 추가), 나머지 Step은 후속 PR에서 반영
- Merged/Extended: apps/gui/docs/ELECTRON_MCP_IPC_SPEC.md, apps/gui/docs/IPC_TERMS_AND_CHANNELS.md, apps/gui/docs/GUI_CODE_STYLE.md
- PR Type Rule: feature/docs update

## Risks / Notes

- Breaking: 없음(내부 구조 정리, 인터페이스 유지)
- Notes: Step 4에서 채널 dot 표기 전환 및 훅/컨테이너 이관 진행 예정
