### PR TITLE
docs: align Slack bot plan with core APIs

### DIFF
--- a/apps/slack-bot/plan/SLACK_AGENT_BOT_SERVER_PLAN.md
+++ b/apps/slack-bot/plan/SLACK_AGENT_BOT_SERVER_PLAN.md
@@ -1,0 +1,146 @@
+# Slack Agent Bot Server Plan
+
+## Requirements
+
+### 성공 조건
+
+- [ ] core 패키지의 `Agent`, `AgentSession`, `CoreContent`를 활용해 **에이전트 실행 파이프라인**을 구성한다.
+- [ ] Slack/Discord 등 커넥터는 `ChatConnector` 제네릭 인터페이스만 구현하면 동일한 에이전트를 재사용할 수 있다.
+- [ ] 채널별로 n개의 에이전트를 등록하고 오케스트레이션 에이전트가 메시지 흐름을 제어한다.
+- [ ] 채널마다 새로운 에이전트를 **동적으로 생성**하여 등록할 수 있다.
+- [ ] LRU+TTL 기반 `AgentCache`로 자주 사용되는 에이전트만 메모리에 유지한다.
+- [ ] 메시지와 응답에는 파일이나 이미지 등 `CoreContent[]` 형태의 첨부가 포함될 수 있다.
+- [ ] NestJS 기반 모듈 구조로 커넥터, 에이전트 실행기, 채널 설정 관리가 분리된다.
+- [ ] 채널별 에이전트 설정을 제공하고 **활성화된 에이전트 목록**을 조회할 수 있다.
+- [ ] MCP 도구·지식·메모리·프리셋·에이전트를 관리할 수 있는 API를 제공하되 모든 로직은 `@agentos/core`의 서비스와 레지스트리를 그대로 활용한다.
+- [ ] 필요한 기능이 core에 없다면 먼저 core 패키지에 기능을 추가한 후 사용한다.
+- [ ] Slack/Discord 커스텀 UX는 slash command 기반으로 제공된다.
+
+### 사용 시나리오
+
+- [ ] 개발자가 여러 에이전트를 등록하고 채널 A에는 요약 에이전트, 채널 B에는 번역 에이전트를 매핑한다.
+- [ ] 채널 C에는 여러 에이전트를 동시에 등록하고, 오케스트레이션 에이전트가 메시지마다 적절한 에이전트를 선택한다.
+- [ ] 관리자가 API를 호출해 채널 D에 새로운 요약 에이전트를 생성하고 즉시 사용할 수 있다.
+- [ ] 사용자가 Slack에서 파일을 첨부해 메시지를 보내면 `attachments`를 통해 전달되고, 결과가 동일 채널로 전송된다.
+- [ ] Discord 커넥터를 추가하더라도 서버 로직 수정 없이 동일한 도메인 모델과 에이전트를 재사용한다.
+- [ ] 사용자는 `/agent add translator` 같은 slash command로 채널에 에이전트를 등록한다.
+- [ ] 관리자는 Slack 커스텀 모달에서 채널별 에이전트 설정 및 MCP 도구·지식·메모리·프리셋을 구성한다.
+
+### 제약 조건
+
+- [ ] Node.js/TypeScript와 NestJS를 사용한다.
+- [ ] 커넥터는 채널·사용자·메시지 등 공통 도메인 개념만 노출하고, 플랫폼별 확장은 제네릭 `meta`로 처리해 OCP를 지킨다.
+- [ ] 외부 의존성은 최소화하고 오픈소스를 우선 사용한다.
+
+## Interface Sketch
+
+```typescript
+import type { Agent, AgentSession, CoreContent } from '@agentos/core';
+
+// 메시지 이벤트
+export interface ChatEvent<M = Record<string, unknown>> {
+  channelId: string;
+  userId: string;
+  text: string;
+  attachments?: CoreContent[];
+  meta?: M;
+}
+
+// 슬래시 커맨드 이벤트
+export interface CommandEvent<M = Record<string, unknown>> {
+  channelId: string;
+  userId: string;
+  command: string; // e.g. /agent
+  args: string[];
+  meta?: M;
+}
+
+// 송신 메시지
+export interface OutgoingMessage<M = Record<string, unknown>> {
+  channelId: string;
+  text: string;
+  attachments?: CoreContent[];
+  meta?: M;
+}
+
+// 커넥터
+export interface ChatConnector<M> {
+  onEvent(handler: (event: ChatEvent<M>) => Promise<void>): void;
+  onCommand?(handler: (command: CommandEvent<M>) => Promise<void>): void;
+  send(message: OutgoingMessage<M>): Promise<void>;
+}
+
+// 에이전트 생성 설정
+export interface AgentConfig {
+  agentId: string;
+  // 모델, 시스템 프롬프트 등 구현체별 옵션
+  options?: Record<string, unknown>;
+}
+
+// 채널별 에이전트 생성/설정 서비스
+export interface ChannelAgentConfigService {
+  createAgent(channelId: string, config: AgentConfig): Promise<Agent>;
+}
+
+// 에이전트 캐시 (LRU+TTL)
+export class AgentCache {
+  constructor(max: number, ttlMs: number) {}
+  get(agentId: string): Agent | undefined;
+  set(agentId: string, agent: Agent): void;
+}
+
+// 채널별 에이전트 매핑
+export interface ChannelAgentRegistry {
+  bindChannel(channelId: string, agentIds: string[]): void;
+  getAgents(channelId: string): Promise<Agent[]>;
+}
+
+// 오케스트레이션 에이전트
+export class OrchestratorAgent implements Agent {
+  constructor(private agents: Agent[]) {}
+  async chat(session: AgentSession, event: ChatEvent): Promise<CoreContent[]> {
+    // 하위 에이전트 실행 순서 및 결과 조합
+    return [];
+  }
+}
+
+// Slack 커넥터 예시
+export type SlackMeta = { ts: string; threadTs?: string };
+
+export class SlackConnector implements ChatConnector<SlackMeta> {
+  constructor(private client: SlackClient) {}
+  onEvent(handler: (event: ChatEvent<SlackMeta>) => Promise<void>): void {
+    // Slack 이벤트를 ChatEvent로 변환
+  }
+  async send(message: OutgoingMessage<SlackMeta>): Promise<void> {
+    await this.client.chat.postMessage({
+      channel: message.channelId,
+      text: message.text,
+      // attachments, meta 처리
+    });
+  }
+}
+```
+
+## Todo
+
+- [ ] ChatEvent·OutgoingMessage에 `attachments`와 제네릭 `meta` 정의
+- [ ] ChatConnector 제네릭 인터페이스 정의
+- [ ] AgentCache(LRU+TTL) 구현
+- [ ] ChannelAgentRegistry가 AgentCache를 활용하도록 구현
+- [ ] OrchestratorAgent 구현 및 채널별 다중 에이전트 제어
+- [ ] ChannelAgentConfigService 및 에이전트 생성 API 구현 (core `AgentService` 활용)
+- [ ] SlackConnector 구현 및 slash command 처리
+- [ ] NestJS 모듈 구성 (AppModule, ConnectorModule, AgentModule, ChannelModule)
+- [ ] core `AgentService`와 각 레지스트리 연동, 채널 매핑·에이전트 관리 API 작성
+- [ ] 활성화된 에이전트 목록 조회 API (`AgentService.listAgents`) 구현
+- [ ] MCP 도구·지식·메모리·프리셋 API를 core 서비스에서 노출
+- [ ] 단위 테스트 작성
+- [ ] 통합 테스트 작성 (채널 매핑 + Slack 이벤트/슬래시 커맨드 모킹)
+- [ ] 문서 업데이트
+
+## 작업 순서
+
+1. **1단계**: ChatEvent·OutgoingMessage·ChatConnector·AgentCache·ChannelAgentRegistry 기본 구현과 NestJS 프로젝트 스캐폴딩
+2. **2단계**: ChannelAgentConfigService, SlackConnector(이벤트·slash command), OrchestratorAgent 구현과 core 서비스 연동, 에이전트 생성·채널 매핑 API, 활성화된 에이전트 목록·MCP·지식·메모리·프리셋 API 노출, LRU 캐시 연동
+3. **3단계**: 단위/통합 테스트와 문서 정리


### PR DESCRIPTION
## Summary
- integrate Slack Agent Bot server plan with existing `@agentos/core` services
- introduce generic slash-command flow via `CommandEvent` and `onCommand`
- clarify TODOs around core API usage and slash command handling

## Testing
- `pnpm format` *(fails: SyntaxError in generated GUI files)*
- `pnpm test` *(fails: '@agentos/lang' missing exports in core tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b179d046f8832eaf9f1faaf1d9cc19