### PR TITLE
Phase 3: Generated controllers promotion confirmed (plan update)

### DIFF
--- a/apps/gui/plan/RPC_AND_STREAMING_CONSOLIDATED_PLAN.md
+++ b/apps/gui/plan/RPC_AND_STREAMING_CONSOLIDATED_PLAN.md
@@ -38,8 +38,8 @@
 
 ### Phase 3 — Nest 컨트롤러 승격
 
-- [ ] `apps/gui/src/main/**/gen/*.controller.gen.new.ts` 승격/모듈 와이어링
-- [ ] DTO/ValidationPipe 적용 및 반환 타입 계약 일치
+- [x] `apps/gui/src/main/**/gen/*.controller.gen.new.ts` 승격/모듈 와이어링
+- [x] DTO/ValidationPipe 적용 및 반환 타입 계약 일치
 - [ ] 기존 services/\* 경로 이관/정리
 
 ### Phase 4 — 레거시 제거/문서


### PR DESCRIPTION
Plan: apps/gui/plan/RPC_AND_STREAMING_CONSOLIDATED_PLAN.md (Phase 3)\n\nScope:\n- Confirm and mark controller promotion in plan (modules already wire Generated* controllers)\n- DTO/ZodValidationPipe and typed returns aligned in prior Phase 2 PR\n\nNotes:\n- Legacy controllers remain; scheduled for Phase 4 cleanup\n\nVerification:\n- No code behavior changes; docs/plan update only\n- Existing tests remain green