### PR TITLE
docs(plan): sync checkmarks with latest main (legacy cleanup, docs indexes)

### DIFF
--- a/apps/gui/plan/DOCS_AND_PLANS_STANDARDIZATION_PLAN.md
+++ b/apps/gui/plan/DOCS_AND_PLANS_STANDARDIZATION_PLAN.md
@@ -30,8 +30,8 @@
 
 ## Todo
 
-- [ ] 누락 가이드 스텁 생성: `apps/gui/docs/RPC_AND_STREAMING_GUIDE.md`
-- [ ] 문서 인덱스 점검: `apps/gui/docs/README.md`, `apps/gui/docs/rpc/README.md`
+- [x] 누락 가이드 스텁 생성: `apps/gui/docs/RPC_AND_STREAMING_GUIDE.md`
+- [x] 문서 인덱스 점검: `apps/gui/docs/README.md`, `apps/gui/docs/rpc/README.md`
 - [ ] 계획서 링크 점검/수정: `apps/gui/plan/*` 내 404 제거
 - [ ] Plan→Docs 승격 체크리스트 작성(기여자 가이드 반영)
 

--- a/apps/gui/plan/RPC_AND_STREAMING_CONSOLIDATED_PLAN.md
+++ b/apps/gui/plan/RPC_AND_STREAMING_CONSOLIDATED_PLAN.md
@@ -18,6 +18,7 @@
 - 서버 컨트롤러: 생성 컨트롤러(bridge/mcp/agent)에서 `as any` 제거 및 반환 타입 엄격화 완료
 - MCP 스트리밍: 서버가 `Observable<z.output<...>>` 반환 패턴으로 복원(스트림 정상 푸시)
 - 참고: 서버 스트리밍 컨벤션 상세는 `apps/gui/plan/RPC_STREAMING_SERVER_CONVENTION_PLAN.md` 참조
+- 레거시 컨트롤러: 수기 컨트롤러(bridge/mcp/preset/agent) 제거로 생성 컨트롤러 체계로 일원화
 
 ## 단계별 계획
 


### PR DESCRIPTION
# Pull Request

## Context

- Plan refresh per latest main: Phase 3 completed state and legacy cleanup reflected
- Files: apps/gui/plan/RPC_AND_STREAMING_CONSOLIDATED_PLAN.md, apps/gui/plan/DOCS_AND_PLANS_STANDARDIZATION_PLAN.md

## Changes

- RPC plan: add status note about legacy controllers removed (generated controllers unified)
- Docs standardization plan: check off stub + index tasks

## Verification

- Docs-only changes; no code impact

## Notes

- Remaining items (Phase 4 docs, link audits) to follow in separate PRs
