### PR TITLE
test(gui): cover dashboard stats card UX

### DIFF
--- a/apps/gui/plan/GUI_CORE_INTEGRATION_PHASE2_PLAN.md
+++ b/apps/gui/plan/GUI_CORE_INTEGRATION_PHASE2_PLAN.md
@@ -9,7 +9,7 @@ Last Updated: 2025-09-19
 
 - [x] SubAgentManager에서 카테고리 필터가 keyword 매핑과 일치하도록 동작하고 단위 테스트로 보강한다. (`SubAgentManager.filter.test.tsx`)
 - [x] Bridge 등록 다이얼로그가 유효/무효 입력과 성공 후 캐시 무효화를 검증하는 테스트를 갖춘다. (`ModelManager.register.test.tsx`)
-- [ ] Dashboard 카드가 실데이터 기반으로 로딩/에러/Retry UX를 제공하고 컴포넌트 테스트가 통과한다.
+- [x] Dashboard 카드가 실데이터 기반으로 로딩/에러/Retry UX를 제공하고 컴포넌트 테스트가 통과한다. (`Dashboard.component.test.tsx`)
 - [ ] KnowledgeBaseManager의 업로드/삭제/검색을 Core RPC 경로로 전환하기 위한 마이그레이션 전략을 수립하고 프로토타입을 완성한다.
 - [ ] MCP 도구 관리에서 usage 이벤트 스트림을 활용한 실시간 갱신 경로와 관련 테스트를 마련한다.
 
@@ -17,7 +17,7 @@ Last Updated: 2025-09-19
 
 - [x] 사용자가 SubAgent 목록 화면에서 카테고리를 선택하면 해당 키워드 매핑에 따라 목록이 필터링된다. (UI & 단위 테스트)
 - [x] 사용자가 Bridge 등록 다이얼로그에 올바른 Manifest JSON을 입력하면 등록 후 목록이 갱신되고, 잘못된 입력 시 명확한 오류가 표시된다. (등록 다이얼로그 테스트)
-- [ ] Dashboard가 로딩/에러/성공 상태를 구분해 보여주고, Retry 시 지표가 재요청된다.
+- [x] Dashboard가 로딩/에러/성공 상태를 구분해 보여주고, Retry 시 지표가 재요청된다. (컴포넌트 테스트로 검증)
 - [ ] Knowledge 문서 추가/삭제/검색이 Core API를 통해 수행되고, 기존 localStorage 데이터는 마이그레이션 유틸로 옮겨진다.
 - [ ] MCP Tool Manager가 usage 이벤트 스트림을 반영해 사용량 패널을 실시간으로 갱신한다.
 
@@ -51,7 +51,7 @@ const { mutateAsync } = useRegisterBridge({
 
 - [x] SubAgentManager 카테고리 필터 단위 테스트 보강
 - [x] Bridge 등록 다이얼로그 유효/무효 입력 및 캐시 무효화 테스트 추가
-- [ ] Dashboard 카드 로딩/에러/Retry 컴포넌트 테스트 작성 및 지표 하드코딩 제거 마무리
+- [x] Dashboard 카드 로딩/에러/Retry 컴포넌트 테스트 작성 및 지표 하드코딩 제거 마무리
 - [ ] Knowledge 마이그레이션 유틸 초안(파일→Core) 설계 및 프로토타입 구현
 - [ ] MCP usage 이벤트 스트림 구독 훅/컴포넌트 업데이트 및 테스트 추가
 - [ ] renderer 테스트 커버리지 가이드라인 문서화 (coverage 목표, 주요 시나리오 명시)
@@ -66,4 +66,3 @@ const { mutateAsync } = useRegisterBridge({
 ## QA & Visual Verification
 
 - [x] Playwright MCP를 이용해 `http://localhost:5173` UI를 직접 검토하고, SubAgentManager 카테고리 필터 및 브릿지 등록 UI가 기존 Figma 디자인과 시각적으로 어긋남 없이 동작함을 확인했다. (2025-09-19)
-

--- a/apps/gui/src/renderer/components/dashboard/__tests__/Dashboard.component.test.tsx
+++ b/apps/gui/src/renderer/components/dashboard/__tests__/Dashboard.component.test.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReadonlyAgentMetadata, Preset } from '@agentos/core';
+import { Dashboard } from '../Dashboard';
+import { useDashboardStats } from '../../../hooks/queries/use-dashboard';
+import { useMcpUsageStream } from '../../../hooks/queries/use-mcp-usage-stream';
+
+vi.mock('../../../hooks/queries/use-dashboard', () => ({
+  useDashboardStats: vi.fn(),
+}));
+
+vi.mock('../../../hooks/queries/use-mcp-usage-stream', () => ({
+  useMcpUsageStream: vi.fn(),
+}));
+
+const useDashboardStatsMock = vi.mocked(useDashboardStats);
+const useMcpUsageStreamMock = vi.mocked(useMcpUsageStream);
+
+const agentsFixture: ReadonlyAgentMetadata[] = [
+  {
+    id: 'agent-active',
+    name: 'Active Agent',
+    description: '',
+    icon: '',
+    keywords: [],
+    preset: {} as Preset,
+    status: 'active',
+    sessionCount: 0,
+    usageCount: 0,
+  },
+  {
+    id: 'agent-idle',
+    name: 'Idle Agent',
+    description: '',
+    icon: '',
+    keywords: [],
+    preset: {} as Preset,
+    status: 'idle',
+    sessionCount: 0,
+    usageCount: 0,
+  },
+];
+
+const presetsFixture: Preset[] = [
+  {
+    id: 'preset-1',
+    name: 'Preset One',
+    description: '',
+    author: 'system',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    version: '1.0.0',
+    systemPrompt: '',
+    llmBridgeName: 'bridge',
+    llmBridgeConfig: {},
+    status: 'active',
+    usageCount: 0,
+    knowledgeDocuments: 0,
+    knowledgeStats: { indexed: 0, vectorized: 0, totalSize: 0 },
+    category: ['general'],
+  },
+];
+
+function renderDashboard(queryClient: QueryClient) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Dashboard
+        presets={presetsFixture}
+        currentAgents={agentsFixture}
+        loading={false}
+        onCreateAgent={() => {}}
+      />
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  useDashboardStatsMock.mockReset();
+  useMcpUsageStreamMock.mockReset();
+});
+
+describe('Dashboard component', () => {
+  it('uses fallback counts while stats are loading', async () => {
+    useDashboardStatsMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    } as ReturnType<typeof useDashboardStats>);
+    useMcpUsageStreamMock.mockReturnValue({ lastEvent: null });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    renderDashboard(qc);
+
+    expect(await screen.findByText('Agents')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('1 active')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /retry-agents/i })).toBeNull();
+    qc.clear();
+  });
+
+  it('shows retry button and invalidates stats on click', async () => {
+    useDashboardStatsMock.mockReturnValue({
+      data: {
+        activeChats: 5,
+        agents: { total: 4, active: 2 },
+        bridges: { total: 3, models: 6 },
+        presets: { total: 6, inUse: 2 },
+        mcp24h: { requests: 10 },
+        meta: {
+          agentsOk: false,
+          bridgesOk: true,
+          chatsOk: true,
+          presetsOk: true,
+          mcpOk: true,
+          mcpHourlyOk: true,
+        },
+      },
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useDashboardStats>);
+    useMcpUsageStreamMock.mockReturnValue({ lastEvent: null });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    renderDashboard(qc);
+
+    const retryButton = await screen.findByRole('button', { name: /retry-agents/i });
+    fireEvent.click(retryButton);
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['dashboard', 'stats'] });
+    qc.clear();
+  });
+
+  it('invalidates stats when MCP usage events arrive', async () => {
+    useDashboardStatsMock.mockReturnValue({
+      data: {
+        activeChats: 0,
+        agents: { total: 0, active: 0 },
+        bridges: { total: 0, models: 0 },
+        presets: { total: 0, inUse: 0 },
+        mcp24h: { requests: null },
+        meta: {
+          agentsOk: true,
+          bridgesOk: true,
+          chatsOk: true,
+          presetsOk: true,
+          mcpOk: true,
+          mcpHourlyOk: true,
+        },
+      },
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useDashboardStats>);
+    useMcpUsageStreamMock.mockReturnValue({ lastEvent: { type: 'stats.updated' } });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    renderDashboard(qc);
+
+    await waitFor(() =>
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['dashboard', 'stats'] })
+    );
+    qc.clear();
+  });
+});


### PR DESCRIPTION
# Summary

Dashboard 카드의 로딩/에러/Retry UX를 Vitest로 검증하는 테스트를 추가하고, Phase 2 계획서에서 해당 TODO를 완료 처리했습니다.

# Motivation & Context

Phase 2 계획의 첫 번째 남은 항목으로 Dashboard 실데이터 카드의 상태 전환을 QA하려면 컴포넌트 테스트가 필요했습니다. 또한 MCP usage 이벤트를 받았을 때 Query invalidation이 이루어지는지 확인해 두면 이후 실시간 반영 작업에 기반이 됩니다.

# Changes

- `Dashboard.component.test.tsx`: 세 가지 시나리오 추가
  - 로딩 중 fallback 값(`currentAgents`, `presets`)과 Retry 버튼 미표시 확인
  - 에러 상태에서 Retry 버튼 노출 및 클릭 시 `invalidateQueries(['dashboard','stats'])` 호출 검증
  - MCP usage 이벤트 발생 시 Query invalidation이 자동으로 수행되는지 검증
- `GUI_CORE_INTEGRATION_PHASE2_PLAN.md`: Dashboard 업무 TODO/성공 조건 상태를 완료로 업데이트

# Checklist

- [x] Git Workflow 준수 (Epic 브랜치 기반 하위 브랜치 → Epic)
- [x] `pnpm --filter @agentos/apps-gui test:renderer`
- [x] 계획서 업데이트

# Breaking Changes

없음

# Follow-ups

- [ ] MCP usage 스트림 UI/UI 테스트 보강
- [ ] Knowledge 마이그레이션 프로토타입
- [ ] Dashboard 카드의 실제 데이터(지표 세부) 추가 개선
