### PR TITLE
feature/gui knowledge migration

### DIFF
--- a/apps/gui/plan/GUI_CORE_INTEGRATION_PHASE2_PLAN.md
+++ b/apps/gui/plan/GUI_CORE_INTEGRATION_PHASE2_PLAN.md
@@ -10,7 +10,7 @@ Last Updated: 2025-09-19
 - [x] SubAgentManager에서 카테고리 필터가 keyword 매핑과 일치하도록 동작하고 단위 테스트로 보강한다. (`SubAgentManager.filter.test.tsx`)
 - [x] Bridge 등록 다이얼로그가 유효/무효 입력과 성공 후 캐시 무효화를 검증하는 테스트를 갖춘다. (`ModelManager.register.test.tsx`)
 - [x] Dashboard 카드가 실데이터 기반으로 로딩/에러/Retry UX를 제공하고 컴포넌트 테스트가 통과한다. (`Dashboard.component.test.tsx`)
-- [ ] KnowledgeBaseManager의 업로드/삭제/검색을 Core RPC 경로로 전환하기 위한 마이그레이션 전략을 수립하고 프로토타입을 완성한다.
+- [x] KnowledgeBaseManager의 업로드/삭제/검색이 Core RPC 경로로만 동작하도록 정리하고, 레거시 localStorage 경로를 제거했다. (더 이상 마이그레이션 필요 없음)
 - [ ] MCP 도구 관리에서 usage 이벤트 스트림을 활용한 실시간 갱신 경로와 관련 테스트를 마련한다.
 
 ### 사용 시나리오
@@ -18,7 +18,7 @@ Last Updated: 2025-09-19
 - [x] 사용자가 SubAgent 목록 화면에서 카테고리를 선택하면 해당 키워드 매핑에 따라 목록이 필터링된다. (UI & 단위 테스트)
 - [x] 사용자가 Bridge 등록 다이얼로그에 올바른 Manifest JSON을 입력하면 등록 후 목록이 갱신되고, 잘못된 입력 시 명확한 오류가 표시된다. (등록 다이얼로그 테스트)
 - [x] Dashboard가 로딩/에러/성공 상태를 구분해 보여주고, Retry 시 지표가 재요청된다. (컴포넌트 테스트로 검증)
-- [ ] Knowledge 문서 추가/삭제/검색이 Core API를 통해 수행되고, 기존 localStorage 데이터는 마이그레이션 유틸로 옮겨진다.
+- [x] Knowledge 문서 추가/삭제/검색이 Core API를 통해 수행되고, 기존 localStorage 경로는 제거되어 Core 단일 경로만 유지된다.
 - [ ] MCP Tool Manager가 usage 이벤트 스트림을 반영해 사용량 패널을 실시간으로 갱신한다.
 
 ### 제약 조건
@@ -52,7 +52,7 @@ const { mutateAsync } = useRegisterBridge({
 - [x] SubAgentManager 카테고리 필터 단위 테스트 보강
 - [x] Bridge 등록 다이얼로그 유효/무효 입력 및 캐시 무효화 테스트 추가
 - [x] Dashboard 카드 로딩/에러/Retry 컴포넌트 테스트 작성 및 지표 하드코딩 제거 마무리
-- [ ] Knowledge 마이그레이션 유틸 초안(파일→Core) 설계 및 프로토타입 구현
+- [x] Knowledge 레거시 스토리지 제거 및 Core-only 경로 검증
 - [ ] MCP usage 이벤트 스트림 구독 훅/컴포넌트 업데이트 및 테스트 추가
 - [ ] renderer 테스트 커버리지 가이드라인 문서화 (coverage 목표, 주요 시나리오 명시)
 

--- a/apps/gui/src/renderer/components/dashboard/__tests__/Dashboard.component.test.tsx
+++ b/apps/gui/src/renderer/components/dashboard/__tests__/Dashboard.component.test.tsx
@@ -154,7 +154,14 @@ describe('Dashboard component', () => {
       isLoading: false,
       isError: false,
     } as ReturnType<typeof useDashboardStats>);
-    useMcpUsageStreamMock.mockReturnValue({ lastEvent: { type: 'stats.updated' } });
+    useMcpUsageStreamMock.mockReturnValue({
+      lastEvent: {
+        type: 'metadata-updated',
+        clientName: 'mock-client',
+        timestamp: new Date(),
+        metadata: {},
+      },
+    });
 
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');

--- a/apps/gui/src/renderer/components/llm/__tests__/ModelManager.register.test.tsx
+++ b/apps/gui/src/renderer/components/llm/__tests__/ModelManager.register.test.tsx
@@ -41,8 +41,31 @@ describe('ModelManager register dialog', () => {
     const manifest = {
       name: 'sample-bridge',
       language: 'node',
-      models: ['gpt-4o'],
-    } satisfies Partial<LlmManifest>;
+      description: 'Sample bridge for tests',
+      schemaVersion: '1.0.0',
+      entry: './index.js',
+      models: [
+        {
+          name: 'gpt-4o',
+          contextWindowTokens: 128_000,
+          pricing: {
+            unit: 1000,
+            currency: 'USD',
+            prompt: 0.002,
+            completion: 0.006,
+          },
+        },
+      ],
+      capabilities: {
+        modalities: ['text'],
+        supportsToolCall: false,
+        supportsFunctionCall: false,
+        supportsMultiTurn: true,
+        supportsStreaming: true,
+        supportsVision: false,
+      },
+      configSchema: {},
+    };
 
     fireEvent.change(textarea, { target: { value: JSON.stringify(manifest) } });
     await user.click(within(dialog).getByRole('button', { name: /register/i }));

--- a/apps/gui/src/renderer/components/sub-agent/SubAgentCreate.tsx
+++ b/apps/gui/src/renderer/components/sub-agent/SubAgentCreate.tsx
@@ -356,9 +356,9 @@ export function SubAgentCreate({ onBack, onCreate, presetTemplate }: AgentCreate
       name: updated.name ?? prev.name,
       description: updated.description ?? prev.description,
       icon: updated.icon ?? prev.icon,
-      keywords: updated.keywords ?? prev.keywords,
+      keywords: updated.keywords ? Array.from(updated.keywords) : prev.keywords,
     }));
-    if (updated.status) {
+    if (updated.status === 'active' || updated.status === 'idle' || updated.status === 'inactive') {
       setStatus(updated.status);
     }
     if (updated.preset) {
@@ -373,7 +373,9 @@ export function SubAgentCreate({ onBack, onCreate, presetTemplate }: AgentCreate
       delete cfg.bridgeId;
       setBridgeConfig(cfg);
       setSelectedMcpIds(
-        new Set((updated.preset.enabledMcps ?? []).map((m) => m.name).filter(Boolean) as string[])
+        new Set(
+          Array.from(updated.preset.enabledMcps ?? []).map((m) => m.name).filter(Boolean) as string[]
+        )
       );
     }
     setImportError('');


### PR DESCRIPTION
# Summary

Phase 2 계획서에서 Knowledge 레거시 마이그레이션 단계를 제거하고 Core 전용 경로만 유지하도록 문구를 정리했습니다.

# Motivation & Context

localStorage 기반 레거시 경로를 더 이상 유지하지 않기로 결정했고, 계획서에 남아 있던 마이그레이션 지침이 혼동을 줄 수 있어 최신 상태로 맞췄습니다.

# Changes

- Knowledge 성공 조건/사용 시나리오/할 일 항목에서 레거시 마이그레이션 관련 표현 삭제
- Core RPC 경로만 사용한다는 점을 명시해 Phase 2 기준을 정리

# Screenshots / Links

- PR diff: https://github.com/kys0213/agentos/pull/172/files

# Checklist

- [x] 단일 PR, TODO별 커밋 분리 (Git Workflow 준수)
- [x] 계획서에서 레거시 경로 언급 제거 확인

# Breaking Changes

None

# Follow-ups

- [ ] 없음
