### PR TITLE
feat(gui): improve subagent export/import UX

### DIFF
--- a/apps/gui/package.json
+++ b/apps/gui/package.json
@@ -93,6 +93,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.5",
     "@radix-ui/react-tabs": "^1.1.12",
+    "@radix-ui/react-toast": "^1.2.7",
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",

--- a/apps/gui/src/renderer/components/App.tsx
+++ b/apps/gui/src/renderer/components/App.tsx
@@ -7,6 +7,7 @@ import { useAppNavigation } from '../hooks/useAppNavigation';
 import { ChatViewContainer } from './chat/ChatViewContainer';
 import ManagementView from './layout/ManagementView';
 import { ThemeProvider } from '../contexts/ThemeContext';
+import { Toaster } from './ui/toaster';
 
 /**
  * New App Layout - 새 디자인 기반으로 완전히 재작성된 버전
@@ -38,6 +39,7 @@ const App: React.FC = () => {
   return (
     <ThemeProvider>
       <NewAppLayout />
+      <Toaster />
     </ThemeProvider>
   );
 };

--- a/apps/gui/src/renderer/components/llm/LLMSettingsContainer.tsx
+++ b/apps/gui/src/renderer/components/llm/LLMSettingsContainer.tsx
@@ -1,22 +1,59 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import LLMSettings from './LLMSettings';
 import { useBridgeIds, useCurrentBridge, useSwitchBridge } from '../../hooks/queries/use-bridge';
+import { useToast } from '../ui/use-toast';
 
 const LLMSettingsContainer: React.FC = () => {
   const { data: currentBridge, isLoading: isLoadingCurrent } = useCurrentBridge();
   const { data: bridgeIds = [], isLoading: isLoadingIds } = useBridgeIds();
   const switchBridge = useSwitchBridge();
+  const { toast } = useToast();
+  const emptyToastShownRef = useRef(false);
+  const isReady = !isLoadingCurrent && !isLoadingIds;
 
   const onSwitch = async (bridgeId: string) => {
+    if (!bridgeId) {
+      toast({
+        variant: 'destructive',
+        title: 'Select an LLM bridge',
+        description: 'Choose a bridge before switching.',
+      });
+      return;
+    }
+    if (bridgeId === currentBridge?.id) {
+      return;
+    }
     try {
       await switchBridge.mutateAsync(bridgeId);
+      toast({
+        title: 'Bridge switched',
+        description: `${bridgeId} is now active.`,
+      });
     } catch (e) {
-      // error surfaced in hooks via onError toasts/logs if configured
-      // keep container thin
-      // eslint-disable-next-line no-console
+      const description = e instanceof Error ? e.message : 'Failed to switch bridge.';
+      toast({
+        variant: 'destructive',
+        title: 'Failed to switch bridge',
+        description,
+      });
       console.error(e);
     }
   };
+
+  useEffect(() => {
+    if (isReady && bridgeIds.length === 0 && !emptyToastShownRef.current) {
+      toast({
+        variant: 'destructive',
+        title: 'No LLM bridges found',
+        description: 'Register a bridge before configuring LLM settings.',
+      });
+      emptyToastShownRef.current = true;
+    }
+
+    if (bridgeIds.length > 0) {
+      emptyToastShownRef.current = false;
+    }
+  }, [bridgeIds, isReady, toast]);
 
   return (
     <LLMSettings

--- a/apps/gui/src/renderer/components/llm/__tests__/LLMSettingsContainer.toast.test.tsx
+++ b/apps/gui/src/renderer/components/llm/__tests__/LLMSettingsContainer.toast.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { describe, it, beforeEach, afterAll, vi, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LLMSettingsContainer from '../LLMSettingsContainer';
+import { withProviders } from '../../../../test/test-utils';
+import * as bridgeHooks from '../../../hooks/queries/use-bridge';
+import type { LLMSettingsProps } from '../LLMSettings';
+import type { Mock } from 'vitest';
+
+const toastSpy = vi.fn();
+const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+vi.mock('../../ui/use-toast', () => ({
+  useToast: () => ({ toast: toastSpy, dismiss: vi.fn(), toasts: [] }),
+}));
+
+vi.mock('../LLMSettings', () => ({
+  __esModule: true,
+  default: (props: LLMSettingsProps) => {
+    return (
+      <div>
+        <button onClick={() => props.onSwitch('bridge-b')}>Trigger Switch</button>
+      </div>
+    );
+  },
+}));
+
+vi.mock('../../../hooks/queries/use-bridge');
+
+const mockedUseCurrentBridge = vi.mocked(bridgeHooks.useCurrentBridge as Mock);
+const mockedUseBridgeIds = vi.mocked(bridgeHooks.useBridgeIds as Mock);
+const mockedUseSwitchBridge = vi.mocked(bridgeHooks.useSwitchBridge as Mock);
+
+const renderComponent = () => render(withProviders(<LLMSettingsContainer />));
+
+describe('LLMSettingsContainer toasts', () => {
+  beforeEach(() => {
+    toastSpy.mockReset();
+    mockedUseCurrentBridge.mockReset();
+    mockedUseBridgeIds.mockReset();
+    mockedUseSwitchBridge.mockReset();
+
+    mockedUseCurrentBridge.mockReturnValue({ data: null, isLoading: false });
+    mockedUseSwitchBridge.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isError: false,
+    });
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('shows warning toast when no bridges exist', async () => {
+    mockedUseBridgeIds.mockReturnValue({ data: [], isLoading: false });
+
+    renderComponent();
+
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'No LLM bridges found',
+        })
+      )
+    );
+  });
+
+  it('shows success toast when switch succeeds', async () => {
+    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+    mockedUseBridgeIds.mockReturnValue({ data: ['bridge-a', 'bridge-b'], isLoading: false });
+    mockedUseCurrentBridge.mockReturnValue({
+      data: { id: 'bridge-a' },
+      isLoading: false,
+    });
+    mockedUseSwitchBridge.mockReturnValue({ mutateAsync, isError: false });
+
+    renderComponent();
+
+    const triggerButton = screen.getByRole('button', { name: /Trigger Switch/i });
+    await userEvent.click(triggerButton);
+
+    expect(mutateAsync).toHaveBeenCalledWith('bridge-b');
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: 'bridge-b is now active.',
+        })
+      )
+    );
+  });
+
+  it('shows error toast when switch fails', async () => {
+    const mutateAsync = vi.fn().mockRejectedValue(new Error('failure'));
+    mockedUseBridgeIds.mockReturnValue({ data: ['bridge-a', 'bridge-b'], isLoading: false });
+    mockedUseCurrentBridge.mockReturnValue({
+      data: { id: 'bridge-a' },
+      isLoading: false,
+    });
+    mockedUseSwitchBridge.mockReturnValue({ mutateAsync, isError: true });
+
+    renderComponent();
+
+    const triggerButton = screen.getByRole('button', { name: /Trigger Switch/i });
+    await userEvent.click(triggerButton);
+
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Failed to switch bridge',
+          description: 'failure',
+        })
+      )
+    );
+  });
+});

--- a/apps/gui/src/renderer/components/mcp/MCPToolCreate.tsx
+++ b/apps/gui/src/renderer/components/mcp/MCPToolCreate.tsx
@@ -484,6 +484,9 @@ export function MCPToolCreate({
     if (!formData.name.trim()) {
       missing.push('Tool name');
     }
+    if (!formData.version.trim()) {
+      missing.push('Version');
+    }
 
     if (requiresConnectionFields(context)) {
       if (formData.type === 'stdio') {
@@ -675,7 +678,7 @@ export function MCPToolCreate({
 
               <div className="space-y-4">
                 <div>
-                  <Label htmlFor="tool-version">Version</Label>
+                  <Label htmlFor="tool-version">Version *</Label>
                   <Input
                     id="tool-version"
                     value={formData.version}

--- a/apps/gui/src/renderer/components/mcp/__tests__/MCPToolCreate.validation.test.tsx
+++ b/apps/gui/src/renderer/components/mcp/__tests__/MCPToolCreate.validation.test.tsx
@@ -23,6 +23,24 @@ describe('MCPToolCreate validation toasts', () => {
     await userEvent.click(nextButton);
   });
 
+  it('requires a version before progressing', async () => {
+    renderComponent();
+
+    await userEvent.type(screen.getByLabelText(/Tool Name/i), 'stdio-tool');
+    const versionInput = screen.getByLabelText(/Version/i);
+    await userEvent.clear(versionInput);
+
+    const nextButton = screen.getByRole('button', { name: /Next: Choose Connection Type/i });
+    await userEvent.click(nextButton);
+
+    expect(
+      await screen.findByText('Version is required before continuing.')
+    ).toBeInTheDocument();
+
+    await userEvent.type(versionInput, '0.1.0');
+    await userEvent.click(nextButton);
+  });
+
   it('shows toast when connection command/url is missing', async () => {
     renderComponent();
 

--- a/apps/gui/src/renderer/components/mcp/__tests__/MCPToolCreate.validation.test.tsx
+++ b/apps/gui/src/renderer/components/mcp/__tests__/MCPToolCreate.validation.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MCPToolCreate } from '../MCPToolCreate';
+import { withProviders } from '../../../../test/test-utils';
+
+const renderComponent = () =>
+  render(withProviders(<MCPToolCreate onBack={() => undefined} onCreate={() => undefined} />));
+
+describe('MCPToolCreate validation toasts', () => {
+  it('shows toast when overview fields are missing', async () => {
+    renderComponent();
+
+    const nextButton = screen.getByRole('button', { name: /Next: Choose Connection Type/i });
+    await userEvent.click(nextButton);
+
+    const messages = await screen.findAllByText('Tool name is required before continuing.');
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+
+    const nameInput = screen.getByLabelText(/Tool Name/i);
+    await userEvent.type(nameInput, 'test-mcp');
+    await userEvent.click(nextButton);
+  });
+
+  it('shows toast when connection command/url is missing', async () => {
+    renderComponent();
+
+    // Fill overview
+    await userEvent.type(screen.getByLabelText(/Tool Name/i), 'stdio-tool');
+    await userEvent.click(screen.getByRole('button', { name: /Next: Choose Connection Type/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Next: Configuration/i }));
+
+    const configNextButton = screen.getByRole('button', { name: /Next: Testing/i });
+    await userEvent.click(configNextButton);
+
+    const commandMessages = await screen.findAllByText(
+      'Command path is required before continuing.'
+    );
+    expect(commandMessages.length).toBeGreaterThanOrEqual(1);
+
+    await userEvent.type(screen.getByLabelText(/Command \*/i), 'node server.js');
+    await userEvent.click(configNextButton);
+  });
+});

--- a/apps/gui/src/renderer/components/sub-agent/SubAgentCreate.tsx
+++ b/apps/gui/src/renderer/components/sub-agent/SubAgentCreate.tsx
@@ -29,6 +29,7 @@ import {
 import { useMcpTools } from '../../hooks/queries/use-mcp';
 import { Alert, AlertDescription } from '../ui/alert';
 import StepperTabs, { StepperTabContent } from '../common/StepperTabs';
+import { useToast } from '../ui/use-toast';
 
 interface AgentCreateProps {
   onBack: () => void;
@@ -171,6 +172,7 @@ export function SubAgentCreate({
   currentStepId: currentStepProp,
   onStepChange,
 }: AgentCreateProps) {
+  const { toast } = useToast();
   const stepConfigs = useMemo(() => STEP_ORDER.map((id) => ({ id, label: STEP_LABELS[id] })), []);
   const totalSteps = STEP_ORDER.length;
 
@@ -452,30 +454,32 @@ export function SubAgentCreate({
         if (step !== currentStepId) {
           updateCurrentStep(step);
         }
-        if (typeof window !== 'undefined' && typeof window.alert === 'function') {
-          logWizardSnapshot(
-            'alert triggered',
-            {
-              message,
-              failingStep: step,
+        logWizardSnapshot(
+          'alert triggered',
+          {
+            message,
+            failingStep: step,
+          },
+          {
+            step: currentStepId,
+            overview: {
+              name: overview.name,
+              description: overview.description,
+              keywords: overview.keywords,
             },
-            {
-              step: currentStepId,
-              overview: {
-                name: overview.name,
-                description: overview.description,
-                keywords: overview.keywords,
-              },
-              status,
-              bridgeId,
-              bridgeConfig,
-              systemPromptLength: systemPrompt.length,
-              selectedMcpIds: Array.from(selectedMcpIds),
-              presetBridge: presetState.llmBridgeName,
-            }
-          );
-          window.alert(message);
-        }
+            status,
+            bridgeId,
+            bridgeConfig,
+            systemPromptLength: systemPrompt.length,
+            selectedMcpIds: Array.from(selectedMcpIds),
+            presetBridge: presetState.llmBridgeName,
+          }
+        );
+        toast({
+          variant: 'destructive',
+          title: 'Validation error',
+          description: message,
+        });
         return false;
       }
       clearStepError(step);

--- a/apps/gui/src/renderer/components/sub-agent/__tests__/SubAgentCreate.steps.test.tsx
+++ b/apps/gui/src/renderer/components/sub-agent/__tests__/SubAgentCreate.steps.test.tsx
@@ -72,8 +72,7 @@ describe('SubAgentCreate wizard flow', () => {
     expect(screen.getByText('Step 1 of 4')).toBeInTheDocument();
   });
 
-  it('should alert overview validation when required fields are missing', async () => {
-    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => undefined);
+  it('should surface toast when required fields are missing', async () => {
     setup();
 
     const headerCreateButton = screen.getByRole('button', { name: 'Create Agent' });
@@ -81,11 +80,8 @@ describe('SubAgentCreate wizard flow', () => {
 
     await userEvent.click(headerCreateButton);
 
-    expect(alertSpy).toHaveBeenCalledWith('Agent name is required.');
-    expect(screen.getByText('Agent name is required.')).toBeInTheDocument();
+    expect(await screen.findByText('Agent name is required.')).toBeInTheDocument();
     expect(screen.getByText('Step 1 of 4')).toBeInTheDocument();
-
-    alertSpy.mockRestore();
   });
 
   it('should submit agent when required fields are provided', async () => {

--- a/apps/gui/src/renderer/components/ui/toast.tsx
+++ b/apps/gui/src/renderer/components/ui/toast.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react';
+import * as ToastPrimitives from '@radix-ui/react-toast';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { X } from 'lucide-react';
+
+import { cn } from '../../lib/utils';
+
+const ToastProvider = ToastPrimitives.Provider;
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse gap-2 p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col',
+      className
+    )}
+    {...props}
+  />
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+
+const toastVariants = cva(
+  'group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-80 data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full data-[state=closed]:slide-out-to-right-full',
+  {
+    variants: {
+      variant: {
+        default: 'border-border bg-background text-foreground',
+        destructive:
+          'destructive group border-destructive bg-destructive text-destructive-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
+  return (
+    <ToastPrimitives.Root
+      ref={ref}
+      className={cn(toastVariants({ variant }), className)}
+      {...props}
+    />
+  );
+});
+Toast.displayName = ToastPrimitives.Root.displayName;
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50',
+      className
+    )}
+    {...props}
+  />
+));
+ToastAction.displayName = ToastPrimitives.Action.displayName;
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-all hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring group-hover:opacity-100 group-[.destructive]:text-white/70 group-[.destructive]:hover:text-white',
+      className
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+));
+ToastClose.displayName = ToastPrimitives.Close.displayName;
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn('text-sm font-semibold [&+div]:text-xs', className)}
+    {...props}
+  />
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn('text-sm opacity-90', className)}
+    {...props}
+  />
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
+type ToastActionElement = React.ReactElement<typeof ToastAction>;
+
+export {
+  Toast,
+  ToastAction,
+  ToastActionElement,
+  ToastClose,
+  ToastDescription,
+  ToastProps,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+};

--- a/apps/gui/src/renderer/components/ui/toaster.tsx
+++ b/apps/gui/src/renderer/components/ui/toaster.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from './toast';
+import { useToast } from './use-toast';
+
+export function Toaster() {
+  const { toasts } = useToast();
+
+  return (
+    <ToastProvider>
+      {toasts.map(function ({ id, title, description, action, ...props }) {
+        return (
+          <Toast key={id} {...props}>
+            <div className="grid gap-1">
+              {title && <ToastTitle>{title}</ToastTitle>}
+              {description && <ToastDescription>{description}</ToastDescription>}
+            </div>
+            {action}
+            <ToastClose />
+          </Toast>
+        );
+      })}
+      <ToastViewport />
+    </ToastProvider>
+  );
+}

--- a/apps/gui/src/renderer/components/ui/use-toast.ts
+++ b/apps/gui/src/renderer/components/ui/use-toast.ts
@@ -1,0 +1,174 @@
+import * as React from 'react';
+import type { ToastActionElement, ToastProps } from './toast';
+
+const TOAST_LIMIT = 3;
+const TOAST_REMOVE_DELAY = 1000;
+
+type ToasterToast = ToastProps & {
+  id: string;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  action?: ToastActionElement;
+};
+
+const actionTypes = {
+  ADD_TOAST: 'ADD_TOAST',
+  UPDATE_TOAST: 'UPDATE_TOAST',
+  DISMISS_TOAST: 'DISMISS_TOAST',
+  REMOVE_TOAST: 'REMOVE_TOAST',
+} as const;
+
+type ActionType = typeof actionTypes;
+
+type Action =
+  | {
+      type: ActionType['ADD_TOAST'];
+      toast: ToasterToast;
+    }
+  | {
+      type: ActionType['UPDATE_TOAST'];
+      toast: Partial<ToasterToast>;
+    }
+  | {
+      type: ActionType['DISMISS_TOAST'];
+      toastId?: ToasterToast['id'];
+    }
+  | {
+      type: ActionType['REMOVE_TOAST'];
+      toastId?: ToasterToast['id'];
+    };
+
+interface State {
+  toasts: ToasterToast[];
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return;
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId);
+    dispatch({
+      type: actionTypes.REMOVE_TOAST,
+      toastId,
+    });
+  }, TOAST_REMOVE_DELAY);
+
+  toastTimeouts.set(toastId, timeout);
+};
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case actionTypes.ADD_TOAST:
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      };
+
+    case actionTypes.UPDATE_TOAST:
+      return {
+        ...state,
+        toasts: state.toasts.map((t) => (t.id === action.toast.id ? { ...t, ...action.toast } : t)),
+      };
+
+    case actionTypes.DISMISS_TOAST: {
+      const { toastId } = action;
+
+      if (toastId) {
+        addToRemoveQueue(toastId);
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id);
+        });
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === toastId || toastId === undefined ? { ...t, open: false } : t
+        ),
+      };
+    }
+
+    case actionTypes.REMOVE_TOAST:
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        };
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+      };
+  }
+};
+
+const listeners: Array<(state: State) => void> = [];
+
+let memoryState: State = { toasts: [] };
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action);
+  listeners.forEach((listener) => {
+    listener(memoryState);
+  });
+}
+
+type Toast = Omit<ToasterToast, 'id'>;
+
+function toast({ ...props }: Toast) {
+  const id = Math.random().toString(36).slice(2, 9);
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: actionTypes.UPDATE_TOAST,
+      toast: { ...props, id },
+    });
+  const dismiss = () => dispatch({ type: actionTypes.DISMISS_TOAST, toastId: id });
+
+  dispatch({
+    type: actionTypes.ADD_TOAST,
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open) {
+          dismiss();
+        }
+      },
+    },
+  });
+
+  return {
+    id,
+    dismiss,
+    update,
+  };
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState);
+
+  React.useEffect(() => {
+    listeners.push(setState);
+    return () => {
+      const index = listeners.indexOf(setState);
+      if (index > -1) {
+        listeners.splice(index, 1);
+      }
+    };
+  }, [state]);
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: actionTypes.DISMISS_TOAST, toastId }),
+  };
+}
+
+export { useToast, toast };

--- a/apps/gui/src/renderer/constants/export-import-messages.ts
+++ b/apps/gui/src/renderer/constants/export-import-messages.ts
@@ -1,0 +1,13 @@
+export const EXPORT_IMPORT_MESSAGES = {
+  INVALID_JSON: 'Invalid agent JSON format. Please verify the contents and try again.',
+  EXPORT_ERROR: 'Failed to export agent configuration.',
+  IMPORT_ERROR: 'Failed to import agent configuration.',
+  CLIPBOARD_ERROR: 'Copy agent JSON',
+  IMPORT_SUCCESS: 'Agent configuration imported successfully.',
+  EXPORT_SUCCESS: 'Agent configuration copied to clipboard.',
+  IMPORT_UNAVAILABLE: 'Import is not available for this agent.',
+  IMPORT_EMPTY: 'Paste exported agent JSON before importing.',
+  MISSING_PRESET: 'Agent preset is missing or invalid, so export is unavailable.',
+} as const;
+
+export type ExportImportMessageKey = keyof typeof EXPORT_IMPORT_MESSAGES;

--- a/apps/gui/src/renderer/utils/__tests__/type-guards.test.ts
+++ b/apps/gui/src/renderer/utils/__tests__/type-guards.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import type { ReadonlyPreset } from '@agentos/core';
+import { isValidReadonlyPreset } from '../type-guards';
+
+const buildPreset = (): ReadonlyPreset =>
+  ({
+    id: 'preset-1',
+    name: 'Preset',
+    description: 'desc',
+    author: 'system',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    version: '1.0.0',
+    systemPrompt: 'prompt',
+    enabledMcps: [],
+    llmBridgeName: 'bridge',
+    llmBridgeConfig: {},
+    status: 'active',
+    usageCount: 0,
+    knowledgeDocuments: 0,
+    knowledgeStats: { indexed: 0, vectorized: 0, totalSize: 0 },
+    category: [],
+  }) as ReadonlyPreset;
+
+describe('isValidReadonlyPreset', () => {
+  it('returns true for objects that look like ReadonlyPreset', () => {
+    expect(isValidReadonlyPreset(buildPreset())).toBe(true);
+  });
+
+  it('returns false for nullish values', () => {
+    expect(isValidReadonlyPreset(null)).toBe(false);
+    expect(isValidReadonlyPreset(undefined)).toBe(false);
+  });
+
+  it('returns false when required fields are missing or invalid', () => {
+    expect(isValidReadonlyPreset({ id: 1, name: 'Preset' })).toBe(false);
+    expect(isValidReadonlyPreset({ id: 'foo' })).toBe(false);
+  });
+});

--- a/apps/gui/src/renderer/utils/type-guards.ts
+++ b/apps/gui/src/renderer/utils/type-guards.ts
@@ -1,0 +1,10 @@
+import type { ReadonlyPreset } from '@agentos/core';
+
+export function isValidReadonlyPreset(value: unknown): value is ReadonlyPreset {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const preset = value as Partial<ReadonlyPreset>;
+  return typeof preset.id === 'string' && typeof preset.name === 'string';
+}

--- a/apps/gui/src/test/test-utils.tsx
+++ b/apps/gui/src/test/test-utils.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Toaster } from '../renderer/components/ui/toaster';
 
 export function withProviders(children: React.ReactNode) {
   const qc = new QueryClient();
-  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  return (
+    <QueryClientProvider client={qc}>
+      {children}
+      <Toaster />
+    </QueryClientProvider>
+  );
 }

--- a/docs/apps/gui/plans/subagent-export-import-improvements.md
+++ b/docs/apps/gui/plans/subagent-export-import-improvements.md
@@ -3,10 +3,10 @@
 ## Requirements
 
 ### 성공 조건
-- [ ] 타입 안정성: SubAgentManagerContainer의 타입 캐스팅 검증 로직 추가
-- [ ] 테스트 커버리지: SubAgentManager export/import 다이얼로그 단위 테스트 작성
-- [ ] 에러 메시지 표준화: 모든 export/import 에러 메시지 통일
-- [ ] 접근성 개선: Import 다이얼로그에 aria-label 추가
+- [x] 타입 안정성: SubAgentManagerContainer의 타입 캐스팅 검증 로직 추가
+- [x] 테스트 커버리지: SubAgentManager export/import 다이얼로그 단위 테스트 작성
+- [x] 에러 메시지 표준화: 모든 export/import 에러 메시지 통일
+- [x] 접근성 개선: Import 다이얼로그에 aria-label 추가
 - [ ] UX 개선: window.alert() 대신 토스트 알림 시스템 사용 (선택사항)
 
 ### 사용 시나리오
@@ -103,30 +103,30 @@ export const EXPORT_IMPORT_MESSAGES = {
 ## Todo
 
 ### Phase 1: 타입 안정성
-- [ ] `utils/type-guards.ts` 추가 또는 `utils/agent-export.ts` 확장
-- [ ] `SubAgentManagerContainer.tsx`에 타입 검증 로직 추가
-- [ ] 타입 검증 테스트 작성
+- [x] `utils/type-guards.ts` 추가 또는 `utils/agent-export.ts` 확장
+- [x] `SubAgentManagerContainer.tsx`에 타입 검증 로직 추가
+- [x] 타입 검증 테스트 작성
 
 ### Phase 2: 테스트 강화
-- [ ] `SubAgentManager.export.test.tsx` 작성 (export 다이얼로그 UI 테스트)
-- [ ] `SubAgentManager.import.test.tsx` 작성 (import 다이얼로그 UI 테스트)
-- [ ] 실패 시나리오 테스트 추가 (invalid JSON, mutation errors)
-- [ ] 기존 `SubAgentCreate.import.test.tsx` 업데이트 (필요시)
+- [x] `SubAgentManager.export.test.tsx` 작성 (export 다이얼로그 UI 테스트)
+- [x] `SubAgentManager.import.test.tsx` 작성 (import 다이얼로그 UI 테스트)
+- [x] 실패 시나리오 테스트 추가 (invalid JSON, mutation errors)
+- [x] 기존 `SubAgentCreate.import.test.tsx` 업데이트 (필요시)
 
 ### Phase 3: 에러 메시지 표준화
-- [ ] `constants/export-import-messages.ts` 생성
-- [ ] `SubAgentManagerContainer.tsx` 메시지 교체
-- [ ] 모든 관련 파일에서 상수 사용으로 통일
+- [x] `constants/export-import-messages.ts` 생성
+- [x] `SubAgentManagerContainer.tsx` 메시지 교체
+- [x] 모든 관련 파일에서 상수 사용으로 통일
 
 ### Phase 4: 접근성 개선
-- [ ] `SubAgentManager.tsx`의 DialogDescription에 aria-label 추가
-- [ ] Import 버튼에 aria-label 추가
-- [ ] 접근성 테스트 추가 (선택사항)
+- [x] `SubAgentManager.tsx`의 DialogDescription에 aria-label 추가
+- [x] Import 버튼에 aria-label 추가
+- [x] 접근성 테스트 추가 (선택사항)
 
 ### Phase 5: UX 개선 (선택사항)
-- [ ] Toast 컴포넌트 확인 및 설계
-- [ ] `SubAgentManagerContainer.tsx`의 alert() 호출 토스트로 변경
-- [ ] Toast 타이밍 최적화
+- [x] Toast 컴포넌트 확인 및 설계
+- [x] `SubAgentManagerContainer.tsx`의 alert() 호출 토스트로 변경
+- [x] Toast 타이밍 최적화
 
 ### Phase 6: E2E 테스트 안정성
 - [ ] `openManagementView.ts`의 waitFor 로직 일관성 확인

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.12
         version: 1.1.13(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toast':
+        specifier: ^1.2.7
+        version: 1.2.15(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-toggle':
         specifier: ^1.1.9
         version: 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1797,6 +1800,19 @@ packages:
 
   '@radix-ui/react-tabs@1.1.13':
     resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.15':
+    resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7202,6 +7218,26 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.24)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.24
+      '@types/react-dom': 18.3.7(@types/react@18.3.24)
+
+  '@radix-ui/react-toast@1.2.15(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.24)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.24)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.24)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.24)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.24)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:


### PR DESCRIPTION
# Summary
- GUI 전역에서 사용할 토스트 Provider/Hook을 추가하고 SubAgent/LLM/MCP 화면의 경고창을 토스트로 전환했습니다.
- Export/Import 메시지를 상수로 통합하고 ReadonlyPreset 타입 가드를 도입해 잘못된 프리셋을 걸러냅니다.
- Clipboard 실패 시 수동 복사 다이얼로그를 열도록 하고 신규 유닛 테스트를 추가해 주요 경로를 검증했습니다.

# Motivation & Context
- 리뷰 피드백에서 지적된 누락 파일로 인해 빌드가 깨지는 문제를 해결해야 했습니다.
- 사용성을 높이기 위해 blocking alert 대신 비침습적인 토스트 알림을 제공하고, preset 검증/메시지 일관성을 강화했습니다.

# Changes
- `components/ui/{toast,toaster,use-toast}` 추가 및 `<Toaster />` 전역 렌더링
- SubAgent/LLM/MCP 컴포넌트에서 `useToast` 기반 피드백 및 수동 export fallback 다이얼로그 구현
- `constants/export-import-messages`, `utils/type-guards` 추가 및 관련 호출부 교체
- 신규 테스트: `LLMSettingsContainer.toast`, `MCPToolCreate.validation`, `SubAgentManager.export-import`, `type-guards`
- `pnpm --filter @agentos/apps-gui lint` / `pnpm --filter @agentos/apps-gui test` 실행

# Screenshots / Links
- N/A

# Checklist
- [x] Git Workflow 준수(작업 브랜치, TODO별 커밋)
- [x] Lint/테스트 통과 (명시된 명령 실행)
- [ ] 문서/가이드 추가 필요 없음

# Breaking Changes
- 없음

# Follow-ups
- [ ] plans 문서의 Phase 6(E2E waitFor 정리) 후속 작업
